### PR TITLE
Add DynamoDb constructs

### DIFF
--- a/packages/docs/@orcabus/namespaces/dynamodb/README.md
+++ b/packages/docs/@orcabus/namespaces/dynamodb/README.md
@@ -1,0 +1,17 @@
+[**@orcabus/platform-cdk-constructs**](../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../README.md) / dynamodb
+
+# dynamodb
+
+## Classes
+
+- [DynamoDbNonPartitionedConstruct](classes/DynamoDbNonPartitionedConstruct.md)
+- [DynamoDbPartitionedConstruct](classes/DynamoDbPartitionedConstruct.md)
+
+## Interfaces
+
+- [DynamoDbNonPartitionedConstructProps](interfaces/DynamoDbNonPartitionedConstructProps.md)
+- [DynamoDbPartitionedConstructProps](interfaces/DynamoDbPartitionedConstructProps.md)

--- a/packages/docs/@orcabus/namespaces/dynamodb/classes/DynamoDbNonPartitionedConstruct.md
+++ b/packages/docs/@orcabus/namespaces/dynamodb/classes/DynamoDbNonPartitionedConstruct.md
@@ -1,0 +1,125 @@
+[**@orcabus/platform-cdk-constructs**](../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../README.md) / [dynamodb](../README.md) / DynamoDbNonPartitionedConstruct
+
+# Class: DynamoDbNonPartitionedConstruct
+
+Defined in: [packages/dynamodb/index.ts:70](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L70)
+
+## Extends
+
+- `Construct`
+
+## Constructors
+
+### Constructor
+
+> **new DynamoDbNonPartitionedConstruct**(`scope`, `id`, `props`): `DynamoDbNonPartitionedConstruct`
+
+Defined in: [packages/dynamodb/index.ts:72](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L72)
+
+#### Parameters
+
+##### scope
+
+`Construct`
+
+##### id
+
+`string`
+
+##### props
+
+[`DynamoDbNonPartitionedConstructProps`](../interfaces/DynamoDbNonPartitionedConstructProps.md)
+
+#### Returns
+
+`DynamoDbNonPartitionedConstruct`
+
+#### Overrides
+
+`Construct.constructor`
+
+## Properties
+
+### node
+
+> `readonly` **node**: `Node`
+
+Defined in: node\_modules/.pnpm/constructs@10.4.2/node\_modules/constructs/lib/construct.d.ts:266
+
+The tree node.
+
+#### Inherited from
+
+`Construct.node`
+
+***
+
+### table
+
+> `readonly` **table**: `TableV2`
+
+Defined in: [packages/dynamodb/index.ts:71](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L71)
+
+## Methods
+
+### toString()
+
+> **toString**(): `string`
+
+Defined in: node\_modules/.pnpm/constructs@10.4.2/node\_modules/constructs/lib/construct.d.ts:279
+
+Returns a string representation of this construct.
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+`Construct.toString`
+
+***
+
+### isConstruct()
+
+> `static` **isConstruct**(`x`): `x is Construct`
+
+Defined in: node\_modules/.pnpm/constructs@10.4.2/node\_modules/constructs/lib/construct.d.ts:262
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+#### Parameters
+
+##### x
+
+`any`
+
+Any object
+
+#### Returns
+
+`x is Construct`
+
+true if `x` is an object created from a class which extends `Construct`.
+
+#### Inherited from
+
+`Construct.isConstruct`

--- a/packages/docs/@orcabus/namespaces/dynamodb/classes/DynamoDbPartitionedConstruct.md
+++ b/packages/docs/@orcabus/namespaces/dynamodb/classes/DynamoDbPartitionedConstruct.md
@@ -1,0 +1,125 @@
+[**@orcabus/platform-cdk-constructs**](../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../README.md) / [dynamodb](../README.md) / DynamoDbPartitionedConstruct
+
+# Class: DynamoDbPartitionedConstruct
+
+Defined in: [packages/dynamodb/index.ts:40](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L40)
+
+## Extends
+
+- `Construct`
+
+## Constructors
+
+### Constructor
+
+> **new DynamoDbPartitionedConstruct**(`scope`, `id`, `props`): `DynamoDbPartitionedConstruct`
+
+Defined in: [packages/dynamodb/index.ts:42](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L42)
+
+#### Parameters
+
+##### scope
+
+`Construct`
+
+##### id
+
+`string`
+
+##### props
+
+[`DynamoDbPartitionedConstructProps`](../interfaces/DynamoDbPartitionedConstructProps.md)
+
+#### Returns
+
+`DynamoDbPartitionedConstruct`
+
+#### Overrides
+
+`Construct.constructor`
+
+## Properties
+
+### node
+
+> `readonly` **node**: `Node`
+
+Defined in: node\_modules/.pnpm/constructs@10.4.2/node\_modules/constructs/lib/construct.d.ts:266
+
+The tree node.
+
+#### Inherited from
+
+`Construct.node`
+
+***
+
+### table
+
+> `readonly` **table**: `TableV2`
+
+Defined in: [packages/dynamodb/index.ts:41](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L41)
+
+## Methods
+
+### toString()
+
+> **toString**(): `string`
+
+Defined in: node\_modules/.pnpm/constructs@10.4.2/node\_modules/constructs/lib/construct.d.ts:279
+
+Returns a string representation of this construct.
+
+#### Returns
+
+`string`
+
+#### Inherited from
+
+`Construct.toString`
+
+***
+
+### isConstruct()
+
+> `static` **isConstruct**(`x`): `x is Construct`
+
+Defined in: node\_modules/.pnpm/constructs@10.4.2/node\_modules/constructs/lib/construct.d.ts:262
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+#### Parameters
+
+##### x
+
+`any`
+
+Any object
+
+#### Returns
+
+`x is Construct`
+
+true if `x` is an object created from a class which extends `Construct`.
+
+#### Inherited from
+
+`Construct.isConstruct`

--- a/packages/docs/@orcabus/namespaces/dynamodb/interfaces/DynamoDbNonPartitionedConstructProps.md
+++ b/packages/docs/@orcabus/namespaces/dynamodb/interfaces/DynamoDbNonPartitionedConstructProps.md
@@ -1,0 +1,432 @@
+[**@orcabus/platform-cdk-constructs**](../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../README.md) / [dynamodb](../README.md) / DynamoDbNonPartitionedConstructProps
+
+# Interface: DynamoDbNonPartitionedConstructProps
+
+Defined in: [packages/dynamodb/index.ts:26](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L26)
+
+## Extends
+
+- `TablePropsV2`
+
+## Properties
+
+### billing?
+
+> `readonly` `optional` **billing**: `Billing`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:225
+
+The billing mode and capacity settings to apply to the table.
+
+#### Default
+
+```ts
+Billing.onDemand()
+```
+
+#### Inherited from
+
+`TablePropsV2.billing`
+
+***
+
+### contributorInsights?
+
+> `readonly` `optional` **contributorInsights**: `boolean`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:101
+
+Whether CloudWatch contributor insights is enabled.
+
+#### Default
+
+```ts
+false
+```
+
+#### Inherited from
+
+`TablePropsV2.contributorInsights`
+
+***
+
+### deletionProtection?
+
+> `readonly` `optional` **deletionProtection**: `boolean`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:107
+
+Whether deletion protection is enabled.
+
+#### Default
+
+```ts
+false
+```
+
+#### Inherited from
+
+`TablePropsV2.deletionProtection`
+
+***
+
+### dynamoStream?
+
+> `readonly` `optional` **dynamoStream**: `StreamViewType`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:213
+
+When an item in the table is modified, StreamViewType determines what information is
+written to the stream.
+
+#### Default
+
+```ts
+- streams are disabled if replicas are not configured and this property is
+not specified. If this property is not specified when replicas are configured, then
+NEW_AND_OLD_IMAGES will be the StreamViewType for all replicas
+```
+
+#### Inherited from
+
+`TablePropsV2.dynamoStream`
+
+***
+
+### encryption?
+
+> `readonly` `optional` **encryption**: `TableEncryptionV2`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:257
+
+The server-side encryption.
+
+#### Default
+
+```ts
+TableEncryptionV2.dynamoOwnedKey()
+```
+
+#### Inherited from
+
+`TablePropsV2.encryption`
+
+***
+
+### globalSecondaryIndexes?
+
+> `readonly` `optional` **globalSecondaryIndexes**: `GlobalSecondaryIndexPropsV2`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:243
+
+Global secondary indexes.
+
+Note: You can provide a maximum of 20 global secondary indexes.
+
+#### Default
+
+```ts
+- no global secondary indexes
+```
+
+#### Inherited from
+
+`TablePropsV2.globalSecondaryIndexes`
+
+***
+
+### kinesisStream?
+
+> `readonly` `optional` **kinesisStream**: `IStream`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:132
+
+Kinesis Data Stream to capture item level changes.
+
+#### Default
+
+```ts
+- no Kinesis Data Stream
+```
+
+#### Inherited from
+
+`TablePropsV2.kinesisStream`
+
+***
+
+### localSecondaryIndexes?
+
+> `readonly` `optional` **localSecondaryIndexes**: `LocalSecondaryIndexProps`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:251
+
+Local secondary indexes.
+
+Note: You can only provide a maximum of 5 local secondary indexes.
+
+#### Default
+
+```ts
+- no local secondary indexes
+```
+
+#### Inherited from
+
+`TablePropsV2.localSecondaryIndexes`
+
+***
+
+### partitionKey
+
+> `readonly` **partitionKey**: `Attribute`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:186
+
+Partition key attribute definition.
+
+#### Inherited from
+
+`TablePropsV2.partitionKey`
+
+***
+
+### partitionKeyName?
+
+> `readonly` `optional` **partitionKeyName**: `string`
+
+Defined in: [packages/dynamodb/index.ts:36](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L36)
+
+Optional, name of the partition key, but by default set to 'id'
+
+***
+
+### ~~pointInTimeRecovery?~~
+
+> `readonly` `optional` **pointInTimeRecovery**: `boolean`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:113
+
+Whether point-in-time recovery is enabled.
+
+#### Deprecated
+
+use `pointInTimeRecoverySpecification` instead
+
+#### Default
+
+```ts
+false - point in time recovery is not enabled.
+```
+
+#### Inherited from
+
+`TablePropsV2.pointInTimeRecovery`
+
+***
+
+### pointInTimeRecoverySpecification?
+
+> `readonly` `optional` **pointInTimeRecoverySpecification**: `PointInTimeRecoverySpecification`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:120
+
+Whether point-in-time recovery is enabled
+and recoveryPeriodInDays is set.
+
+#### Default
+
+```ts
+- point in time recovery is not enabled.
+```
+
+#### Inherited from
+
+`TablePropsV2.pointInTimeRecoverySpecification`
+
+***
+
+### removalPolicy?
+
+> `readonly` `optional` **removalPolicy**: `RemovalPolicy`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:219
+
+The removal policy applied to the table.
+
+#### Default
+
+```ts
+RemovalPolicy.RETAIN
+```
+
+#### Inherited from
+
+`TablePropsV2.removalPolicy`
+
+***
+
+### replicas?
+
+> `readonly` `optional` **replicas**: `ReplicaTableProps`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:235
+
+Replica tables to deploy with the primary table.
+
+Note: Adding replica tables allows you to use your table as a global table. You
+cannot specify a replica table in the region that the primary table will be deployed
+to. Replica tables will only be supported if the stack deployment region is defined.
+
+#### Default
+
+```ts
+- no replica tables
+```
+
+#### Inherited from
+
+`TablePropsV2.replicas`
+
+***
+
+### resourcePolicy?
+
+> `readonly` `optional` **resourcePolicy**: `PolicyDocument`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:144
+
+Resource policy to assign to DynamoDB Table.
+
+#### See
+
+https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-globaltable-replicaspecification.html#cfn-dynamodb-globaltable-replicaspecification-resourcepolicy
+
+#### Default
+
+```ts
+- No resource policy statements are added to the created table.
+```
+
+#### Inherited from
+
+`TablePropsV2.resourcePolicy`
+
+***
+
+### sortKey?
+
+> `readonly` `optional` **sortKey**: `Attribute`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:192
+
+Sort key attribute definition.
+
+#### Default
+
+```ts
+- no sort key
+```
+
+#### Inherited from
+
+`TablePropsV2.sortKey`
+
+***
+
+### tableClass?
+
+> `readonly` `optional` **tableClass**: `TableClass`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:126
+
+The table class.
+
+#### Default
+
+```ts
+TableClass.STANDARD
+```
+
+#### Inherited from
+
+`TablePropsV2.tableClass`
+
+***
+
+### tableName
+
+> `readonly` **tableName**: `string`
+
+Defined in: [packages/dynamodb/index.ts:31](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L31)
+
+The name of the table.
+We force this to be set so that the table can be used across multiple stacks.
+
+#### Overrides
+
+`TablePropsV2.tableName`
+
+***
+
+### tags?
+
+> `readonly` `optional` **tags**: `CfnTag`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:138
+
+Tags to be applied to the primary table (default replica table).
+
+#### Default
+
+```ts
+- no tags
+```
+
+#### Inherited from
+
+`TablePropsV2.tags`
+
+***
+
+### timeToLiveAttribute?
+
+> `readonly` `optional` **timeToLiveAttribute**: `string`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:204
+
+The name of the TTL attribute.
+
+#### Default
+
+```ts
+- TTL is disabled
+```
+
+#### Inherited from
+
+`TablePropsV2.timeToLiveAttribute`
+
+***
+
+### warmThroughput?
+
+> `readonly` `optional` **warmThroughput**: `WarmThroughput`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:263
+
+The warm throughput configuration for the table.
+
+#### Default
+
+```ts
+- no warm throughput is configured
+```
+
+#### Inherited from
+
+`TablePropsV2.warmThroughput`

--- a/packages/docs/@orcabus/namespaces/dynamodb/interfaces/DynamoDbPartitionedConstructProps.md
+++ b/packages/docs/@orcabus/namespaces/dynamodb/interfaces/DynamoDbPartitionedConstructProps.md
@@ -1,0 +1,442 @@
+[**@orcabus/platform-cdk-constructs**](../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../README.md) / [dynamodb](../README.md) / DynamoDbPartitionedConstructProps
+
+# Interface: DynamoDbPartitionedConstructProps
+
+Defined in: [packages/dynamodb/index.ts:7](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L7)
+
+## Extends
+
+- `TablePropsV2`
+
+## Properties
+
+### billing?
+
+> `readonly` `optional` **billing**: `Billing`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:225
+
+The billing mode and capacity settings to apply to the table.
+
+#### Default
+
+```ts
+Billing.onDemand()
+```
+
+#### Inherited from
+
+`TablePropsV2.billing`
+
+***
+
+### contributorInsights?
+
+> `readonly` `optional` **contributorInsights**: `boolean`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:101
+
+Whether CloudWatch contributor insights is enabled.
+
+#### Default
+
+```ts
+false
+```
+
+#### Inherited from
+
+`TablePropsV2.contributorInsights`
+
+***
+
+### deletionProtection?
+
+> `readonly` `optional` **deletionProtection**: `boolean`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:107
+
+Whether deletion protection is enabled.
+
+#### Default
+
+```ts
+false
+```
+
+#### Inherited from
+
+`TablePropsV2.deletionProtection`
+
+***
+
+### dynamoStream?
+
+> `readonly` `optional` **dynamoStream**: `StreamViewType`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:213
+
+When an item in the table is modified, StreamViewType determines what information is
+written to the stream.
+
+#### Default
+
+```ts
+- streams are disabled if replicas are not configured and this property is
+not specified. If this property is not specified when replicas are configured, then
+NEW_AND_OLD_IMAGES will be the StreamViewType for all replicas
+```
+
+#### Inherited from
+
+`TablePropsV2.dynamoStream`
+
+***
+
+### encryption?
+
+> `readonly` `optional` **encryption**: `TableEncryptionV2`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:257
+
+The server-side encryption.
+
+#### Default
+
+```ts
+TableEncryptionV2.dynamoOwnedKey()
+```
+
+#### Inherited from
+
+`TablePropsV2.encryption`
+
+***
+
+### globalSecondaryIndexes?
+
+> `readonly` `optional` **globalSecondaryIndexes**: `GlobalSecondaryIndexPropsV2`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:243
+
+Global secondary indexes.
+
+Note: You can provide a maximum of 20 global secondary indexes.
+
+#### Default
+
+```ts
+- no global secondary indexes
+```
+
+#### Inherited from
+
+`TablePropsV2.globalSecondaryIndexes`
+
+***
+
+### kinesisStream?
+
+> `readonly` `optional` **kinesisStream**: `IStream`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:132
+
+Kinesis Data Stream to capture item level changes.
+
+#### Default
+
+```ts
+- no Kinesis Data Stream
+```
+
+#### Inherited from
+
+`TablePropsV2.kinesisStream`
+
+***
+
+### localSecondaryIndexes?
+
+> `readonly` `optional` **localSecondaryIndexes**: `LocalSecondaryIndexProps`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:251
+
+Local secondary indexes.
+
+Note: You can only provide a maximum of 5 local secondary indexes.
+
+#### Default
+
+```ts
+- no local secondary indexes
+```
+
+#### Inherited from
+
+`TablePropsV2.localSecondaryIndexes`
+
+***
+
+### partitionKey
+
+> `readonly` **partitionKey**: `Attribute`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:186
+
+Partition key attribute definition.
+
+#### Inherited from
+
+`TablePropsV2.partitionKey`
+
+***
+
+### partitionKeyName?
+
+> `readonly` `optional` **partitionKeyName**: `string`
+
+Defined in: [packages/dynamodb/index.ts:17](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L17)
+
+Optional, name of the partition key, but by default set to 'id'
+
+***
+
+### ~~pointInTimeRecovery?~~
+
+> `readonly` `optional` **pointInTimeRecovery**: `boolean`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:113
+
+Whether point-in-time recovery is enabled.
+
+#### Deprecated
+
+use `pointInTimeRecoverySpecification` instead
+
+#### Default
+
+```ts
+false - point in time recovery is not enabled.
+```
+
+#### Inherited from
+
+`TablePropsV2.pointInTimeRecovery`
+
+***
+
+### pointInTimeRecoverySpecification?
+
+> `readonly` `optional` **pointInTimeRecoverySpecification**: `PointInTimeRecoverySpecification`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:120
+
+Whether point-in-time recovery is enabled
+and recoveryPeriodInDays is set.
+
+#### Default
+
+```ts
+- point in time recovery is not enabled.
+```
+
+#### Inherited from
+
+`TablePropsV2.pointInTimeRecoverySpecification`
+
+***
+
+### removalPolicy?
+
+> `readonly` `optional` **removalPolicy**: `RemovalPolicy`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:219
+
+The removal policy applied to the table.
+
+#### Default
+
+```ts
+RemovalPolicy.RETAIN
+```
+
+#### Inherited from
+
+`TablePropsV2.removalPolicy`
+
+***
+
+### replicas?
+
+> `readonly` `optional` **replicas**: `ReplicaTableProps`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:235
+
+Replica tables to deploy with the primary table.
+
+Note: Adding replica tables allows you to use your table as a global table. You
+cannot specify a replica table in the region that the primary table will be deployed
+to. Replica tables will only be supported if the stack deployment region is defined.
+
+#### Default
+
+```ts
+- no replica tables
+```
+
+#### Inherited from
+
+`TablePropsV2.replicas`
+
+***
+
+### resourcePolicy?
+
+> `readonly` `optional` **resourcePolicy**: `PolicyDocument`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:144
+
+Resource policy to assign to DynamoDB Table.
+
+#### See
+
+https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-globaltable-replicaspecification.html#cfn-dynamodb-globaltable-replicaspecification-resourcepolicy
+
+#### Default
+
+```ts
+- No resource policy statements are added to the created table.
+```
+
+#### Inherited from
+
+`TablePropsV2.resourcePolicy`
+
+***
+
+### sortKey?
+
+> `readonly` `optional` **sortKey**: `Attribute`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:192
+
+Sort key attribute definition.
+
+#### Default
+
+```ts
+- no sort key
+```
+
+#### Inherited from
+
+`TablePropsV2.sortKey`
+
+***
+
+### sortKeyName?
+
+> `readonly` `optional` **sortKeyName**: `string`
+
+Defined in: [packages/dynamodb/index.ts:22](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L22)
+
+Optional, name of the sort key, but by default set to 'id_type'
+
+***
+
+### tableClass?
+
+> `readonly` `optional` **tableClass**: `TableClass`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:126
+
+The table class.
+
+#### Default
+
+```ts
+TableClass.STANDARD
+```
+
+#### Inherited from
+
+`TablePropsV2.tableClass`
+
+***
+
+### tableName
+
+> `readonly` **tableName**: `string`
+
+Defined in: [packages/dynamodb/index.ts:12](https://github.com/orcabus/platform-cdk-constructs/blob/108d0b71eb752a4283adc0a5149703d39ba2dfc6/packages/dynamodb/index.ts#L12)
+
+The name of the table.
+We force this to be set so that the table can be used across multiple stacks.
+
+#### Overrides
+
+`TablePropsV2.tableName`
+
+***
+
+### tags?
+
+> `readonly` `optional` **tags**: `CfnTag`[]
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:138
+
+Tags to be applied to the primary table (default replica table).
+
+#### Default
+
+```ts
+- no tags
+```
+
+#### Inherited from
+
+`TablePropsV2.tags`
+
+***
+
+### timeToLiveAttribute?
+
+> `readonly` `optional` **timeToLiveAttribute**: `string`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:204
+
+The name of the TTL attribute.
+
+#### Default
+
+```ts
+- TTL is disabled
+```
+
+#### Inherited from
+
+`TablePropsV2.timeToLiveAttribute`
+
+***
+
+### warmThroughput?
+
+> `readonly` `optional` **warmThroughput**: `WarmThroughput`
+
+Defined in: node\_modules/.pnpm/aws-cdk-lib@2.195.0\_constructs@10.4.2/node\_modules/aws-cdk-lib/aws-dynamodb/lib/table-v2.d.ts:263
+
+The warm throughput configuration for the table.
+
+#### Default
+
+```ts
+- no warm throughput is configured
+```
+
+#### Inherited from
+
+`TablePropsV2.warmThroughput`

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -8,4 +8,5 @@
 
 - [apigateway](@orcabus/namespaces/apigateway/README.md)
 - [deploymentPipeline](@orcabus/namespaces/deploymentPipeline/README.md)
+- [dynamodb](@orcabus/namespaces/dynamodb/README.md)
 - [utils](@orcabus/namespaces/utils/README.md)

--- a/packages/dynamodb/config.ts
+++ b/packages/dynamodb/config.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_PARTITION_KEY_NAME = 'id'
+export const DEFAULT_SORT_KEY_NAME = 'id_type'
+export const DEFAULT_TIME_TO_LIVE_EXPIRY_KEY_NAME = 'expire_at'

--- a/packages/dynamodb/index.ts
+++ b/packages/dynamodb/index.ts
@@ -1,0 +1,76 @@
+import {Construct} from 'constructs';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import {RemovalPolicy} from 'aws-cdk-lib';
+import {TablePropsV2} from "aws-cdk-lib/aws-dynamodb";
+import {DEFAULT_PARTITION_KEY_NAME, DEFAULT_SORT_KEY_NAME, DEFAULT_TIME_TO_LIVE_EXPIRY_KEY_NAME} from "./config";
+
+export interface DynamoDbPartitionedPipelineConstructProps extends TablePropsV2 {
+    tableName: string
+    partitionKeyName?: string
+    sortKeyName?: string
+}
+
+
+export interface DynamoDbNonPartitionedPipelineConstructProps extends TablePropsV2 {
+    tableName: string
+    partitionKeyName?: string
+}
+
+
+export class DynamoDbPartitionedPipelineConstruct extends Construct {
+    public readonly table: dynamodb.TableV2;
+    constructor(scope: Construct, id: string, props: DynamoDbPartitionedPipelineConstructProps) {
+        super(scope, id);
+
+        this.table = new dynamodb.TableV2(this, props.tableName, {
+            ...props,
+            /* Set the table name */
+            tableName: props.tableName,
+            /* Unique id across the sort key */
+            partitionKey: {
+                name: props.partitionKeyName ?? DEFAULT_PARTITION_KEY_NAME,
+                type: dynamodb.AttributeType.STRING,
+            },
+            /* Categorical key */
+            sortKey: {
+                name: props.sortKeyName ?? DEFAULT_SORT_KEY_NAME,
+                type: dynamodb.AttributeType.STRING,
+            },
+            /* Backup / removal policies */
+            removalPolicy: props.removalPolicy || RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE,
+            pointInTimeRecoverySpecification: {
+                pointInTimeRecoveryEnabled: true,
+            },
+            /* Time to live attribute - helps keep the database a healthy size */
+            timeToLiveAttribute: props.timeToLiveAttribute ?? DEFAULT_TIME_TO_LIVE_EXPIRY_KEY_NAME
+        });
+    }
+}
+
+export class DynamoDbNonPartitionedPipelineConstruct extends Construct {
+    public readonly table: dynamodb.TableV2;
+    constructor(scope: Construct, id: string, props: DynamoDbNonPartitionedPipelineConstructProps) {
+        super(scope, id);
+
+        this.table = new dynamodb.TableV2(this, props.tableName, {
+            /* Set the table name */
+            tableName: props.tableName,
+            /* A globally unique identifier */
+            partitionKey: {
+                name: props.partitionKeyName ?? DEFAULT_PARTITION_KEY_NAME,
+                type: dynamodb.AttributeType.STRING,
+            },
+            /* Backup / removal policies */
+            removalPolicy: props.removalPolicy || RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE,
+            pointInTimeRecoverySpecification: {
+                pointInTimeRecoveryEnabled: true,
+            },
+            /* Time to live attribute - helps keep the database a healthy size */
+            timeToLiveAttribute: props.timeToLiveAttribute ?? DEFAULT_TIME_TO_LIVE_EXPIRY_KEY_NAME
+        });
+    }
+}
+
+
+
+

--- a/packages/dynamodb/index.ts
+++ b/packages/dynamodb/index.ts
@@ -4,22 +4,42 @@ import {RemovalPolicy} from 'aws-cdk-lib';
 import {TablePropsV2} from "aws-cdk-lib/aws-dynamodb";
 import {DEFAULT_PARTITION_KEY_NAME, DEFAULT_SORT_KEY_NAME, DEFAULT_TIME_TO_LIVE_EXPIRY_KEY_NAME} from "./config";
 
-export interface DynamoDbPartitionedPipelineConstructProps extends TablePropsV2 {
-    tableName: string
-    partitionKeyName?: string
-    sortKeyName?: string
+export interface DynamoDbPartitionedConstructProps extends TablePropsV2 {
+    /**
+     * The name of the table.
+     * We force this to be set so that the table can be used across multiple stacks.
+     */
+    readonly tableName: string
+
+     /**
+     * Optional, name of the partition key, but by default set to 'id'
+     */
+    readonly partitionKeyName?: string
+
+    /**
+    *  Optional, name of the sort key, but by default set to 'id_type'
+    */
+    readonly sortKeyName?: string
 }
 
 
-export interface DynamoDbNonPartitionedPipelineConstructProps extends TablePropsV2 {
-    tableName: string
-    partitionKeyName?: string
+export interface DynamoDbNonPartitionedConstructProps extends TablePropsV2 {
+    /**
+     * The name of the table.
+     * We force this to be set so that the table can be used across multiple stacks.
+    */
+    readonly tableName: string
+
+    /**
+     * Optional, name of the partition key, but by default set to 'id'
+    */
+    readonly partitionKeyName?: string
 }
 
 
-export class DynamoDbPartitionedPipelineConstruct extends Construct {
+export class DynamoDbPartitionedConstruct extends Construct {
     public readonly table: dynamodb.TableV2;
-    constructor(scope: Construct, id: string, props: DynamoDbPartitionedPipelineConstructProps) {
+    constructor(scope: Construct, id: string, props: DynamoDbPartitionedConstructProps) {
         super(scope, id);
 
         this.table = new dynamodb.TableV2(this, props.tableName, {
@@ -47,9 +67,9 @@ export class DynamoDbPartitionedPipelineConstruct extends Construct {
     }
 }
 
-export class DynamoDbNonPartitionedPipelineConstruct extends Construct {
+export class DynamoDbNonPartitionedConstruct extends Construct {
     public readonly table: dynamodb.TableV2;
-    constructor(scope: Construct, id: string, props: DynamoDbNonPartitionedPipelineConstructProps) {
+    constructor(scope: Construct, id: string, props: DynamoDbNonPartitionedConstructProps) {
         super(scope, id);
 
         this.table = new dynamodb.TableV2(this, props.tableName, {

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -6,3 +6,6 @@ export * as deploymentPipeline from "./deployment-stack-pipeline";
 
 // Api Gateway constructs
 export * as apigateway from "./api-gateway";
+
+// DynamoDB Constructs
+export * as dynamodb from "./dynamodb";

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,3 +1,8 @@
 // Get stage name
-export * as deploymentPipeline from "./deployment-stack-pipeline";
 export * as utils from "./utils";
+
+// Deployment pipeline constructs
+export * as deploymentPipeline from "./deployment-stack-pipeline";
+
+// Api Gateway constructs
+export * as apigateway from "./api-gateway";

--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,3 +1,3 @@
-export * as apigateway from "./api-gateway";
+// Get stage name
 export * as deploymentPipeline from "./deployment-stack-pipeline";
 export * as utils from "./utils";

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -1,0 +1,878 @@
+{
+  "name": "@orcabus/platform-cdk-constructs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@orcabus/platform-cdk-constructs",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@aws-cdk/aws-lambda-python-alpha": "2.195.0-alpha.0",
+        "@types/node": "^22.13.10",
+        "aws-cdk": "^2.1006.0",
+        "aws-cdk-lib": "2.195.0",
+        "constructs": "10.4.2",
+        "jsii": "^5.8.3",
+        "jsii-pacmak": "^1.110.0",
+        "publib": "^0.2.965",
+        "typedoc": "^0.28.2",
+        "typedoc-plugin-markdown": "^4.6.2"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.183.0",
+        "constructs": "^10.4.2"
+      }
+    },
+    "../node_modules/.pnpm/aws-cdk@2.1006.0/node_modules/aws-cdk": {
+      "version": "2.1006.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "devDependencies": {
+        "@aws-cdk/cli-plugin-contract": "2.180.0",
+        "@aws-cdk/cloud-assembly-schema": "42.0.0",
+        "@aws-cdk/cloudformation-diff": "2.180.0",
+        "@aws-cdk/cx-api": "^2.185.0",
+        "@aws-cdk/node-bundle": "0.0.0",
+        "@aws-cdk/region-info": "^2.185.0",
+        "@aws-cdk/tmp-toolkit-helpers": "0.0.0",
+        "@aws-cdk/user-input-gen": "0.0.0",
+        "@aws-sdk/client-appsync": "^3",
+        "@aws-sdk/client-cloudcontrol": "^3",
+        "@aws-sdk/client-cloudformation": "^3",
+        "@aws-sdk/client-cloudwatch-logs": "^3",
+        "@aws-sdk/client-codebuild": "^3",
+        "@aws-sdk/client-ec2": "^3",
+        "@aws-sdk/client-ecr": "^3",
+        "@aws-sdk/client-ecs": "^3",
+        "@aws-sdk/client-elastic-load-balancing-v2": "^3",
+        "@aws-sdk/client-iam": "^3",
+        "@aws-sdk/client-kms": "^3",
+        "@aws-sdk/client-lambda": "^3",
+        "@aws-sdk/client-route-53": "^3",
+        "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/client-secrets-manager": "^3",
+        "@aws-sdk/client-sfn": "^3",
+        "@aws-sdk/client-ssm": "^3",
+        "@aws-sdk/client-sts": "^3",
+        "@aws-sdk/credential-providers": "^3",
+        "@aws-sdk/ec2-metadata-service": "^3",
+        "@aws-sdk/lib-storage": "^3",
+        "@aws-sdk/middleware-endpoint": "^3.374.0",
+        "@aws-sdk/util-retry": "^3.374.0",
+        "@aws-sdk/util-waiter": "^3.374.0",
+        "@cdklabs/eslint-plugin": "^1.3.2",
+        "@octokit/rest": "^21.1.1",
+        "@smithy/middleware-endpoint": "^4.0.6",
+        "@smithy/property-provider": "^4.0.1",
+        "@smithy/shared-ini-file-loader": "^4.0.1",
+        "@smithy/types": "^4.1.0",
+        "@smithy/util-retry": "^4.0.1",
+        "@smithy/util-stream": "^4.1.2",
+        "@smithy/util-waiter": "^4.0.2",
+        "@stylistic/eslint-plugin": "^3",
+        "@types/archiver": "^6.0.3",
+        "@types/fs-extra": "^9",
+        "@types/jest": "^29.5.14",
+        "@types/mockery": "^1.4.33",
+        "@types/node": "^16",
+        "@types/promptly": "^3.0.5",
+        "@types/semver": "^7.5.8",
+        "@types/sinon": "^17.0.4",
+        "@types/yargs": "^15",
+        "@typescript-eslint/eslint-plugin": "^8",
+        "@typescript-eslint/parser": "^8",
+        "archiver": "^7.0.1",
+        "aws-cdk-lib": "^2.185.0",
+        "axios": "^1.8.4",
+        "camelcase": "^6",
+        "cdk-assets": "^3.2.0",
+        "cdk-from-cfn": "0.162.1",
+        "chalk": "^4",
+        "chokidar": "^3",
+        "commit-and-tag-version": "^12",
+        "constructs": "^10.0.0",
+        "decamelize": "^5",
+        "eslint": "^9",
+        "eslint-config-prettier": "^10.1.1",
+        "eslint-import-resolver-typescript": "^3.9.1",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jest": "^28.11.0",
+        "eslint-plugin-jsdoc": "^50.6.9",
+        "eslint-plugin-prettier": "^5.2.3",
+        "fast-check": "^3.23.2",
+        "fs-extra": "^9",
+        "glob": "^11.0.1",
+        "jest": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-junit": "^16",
+        "jest-mock": "^29.7.0",
+        "license-checker": "^25.0.1",
+        "madge": "^8.0.0",
+        "minimatch": "^10.0.1",
+        "nock": "^14.0.1",
+        "p-limit": "^3",
+        "prettier": "^2.8",
+        "projen": "^0.91.18",
+        "promptly": "^3.2.0",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.1",
+        "sinon": "^19.0.4",
+        "strip-ansi": "^6",
+        "table": "^6.9.0",
+        "ts-jest": "^29.2.6",
+        "ts-mock-imports": "^1.3.16",
+        "typescript": "5.6",
+        "uuid": "^11.1.0",
+        "wrap-ansi": "^7",
+        "xml-js": "^1.6.11",
+        "yaml": "^1",
+        "yargs": "^15"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "../node_modules/.pnpm/constructs@10.4.2/node_modules/constructs": {
+      "version": "10.4.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/jest": "^29",
+        "@types/node": "^18",
+        "@typescript-eslint/eslint-plugin": "^7",
+        "@typescript-eslint/parser": "^7",
+        "cdklabs-projen-project-types": "^0.1.204",
+        "commit-and-tag-version": "^12",
+        "eslint": "^8",
+        "eslint-import-resolver-typescript": "^3.6.3",
+        "eslint-plugin-import": "^2.31.0",
+        "jest": "^29",
+        "jest-junit": "^15",
+        "jsii": "5.4.x",
+        "jsii-diff": "^1.104.0",
+        "jsii-docgen": "^10.5.0",
+        "jsii-pacmak": "1.102.0",
+        "jsii-rosetta": "5.4.x",
+        "projen": "^0.87.4",
+        "ts-jest": "^29",
+        "ts-node": "^10.9.2",
+        "typescript": "5.4.x"
+      }
+    },
+    "../node_modules/.pnpm/jsii-pacmak@1.110.0_jsii-rosetta@5.8.0/node_modules/jsii-pacmak": {
+      "version": "1.110.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsii/check-node": "1.110.0",
+        "@jsii/spec": "^1.110.0",
+        "clone": "^2.1.2",
+        "codemaker": "^1.110.0",
+        "commonmark": "^0.31.2",
+        "escape-string-regexp": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "jsii-reflect": "^1.110.0",
+        "semver": "^7.7.1",
+        "spdx-license-list": "^6.9.0",
+        "xmlbuilder": "^15.1.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "jsii-pacmak": "bin/jsii-pacmak"
+      },
+      "devDependencies": {
+        "@jsii/dotnet-runtime": "^1.110.0",
+        "@jsii/go-runtime": "^1.110.0",
+        "@jsii/java-runtime": "^1.110.0",
+        "@scope/jsii-calc-lib": "^1.110.0",
+        "@types/clone": "^2.1.4",
+        "@types/commonmark": "^0.27.9",
+        "@types/diff": "^5.2.3",
+        "@types/fs-extra": "^9.0.13",
+        "@types/semver": "^7.5.8",
+        "diff": "^5.2.0",
+        "jsii": "^5.8.0",
+        "jsii-build-tools": "^1.110.0",
+        "jsii-calc": "^3.20.120",
+        "jsii-rosetta": "~5.8.0",
+        "pyright": "^1.1.395"
+      },
+      "engines": {
+        "node": ">= 14.17.0"
+      },
+      "peerDependencies": {
+        "jsii-rosetta": ">=5.5.0"
+      }
+    },
+    "../node_modules/.pnpm/jsii@5.8.3/node_modules/jsii": {
+      "version": "5.8.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsii/check-node": "1.110.0",
+        "@jsii/spec": "^1.110.0",
+        "case": "^1.6.3",
+        "chalk": "^4",
+        "fast-deep-equal": "^3.1.3",
+        "log4js": "^6.9.1",
+        "semver": "^7.7.1",
+        "semver-intersect": "^1.5.0",
+        "sort-json": "^2.0.1",
+        "spdx-license-list": "^6.9.0",
+        "typescript": "~5.8",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "jsii": "bin/jsii"
+      },
+      "devDependencies": {
+        "@actions/core": "^1.11.1",
+        "@actions/github": "^5.1.1",
+        "@types/clone": "^2.1.4",
+        "@types/deep-equal": "^1.0.4",
+        "@types/glob": "^8.1.0",
+        "@types/jest": "^29.5.14",
+        "@types/lockfile": "^1.0.4",
+        "@types/node": "^18",
+        "@types/semver": "^7.7.0",
+        "@types/tar": "^6.1.13",
+        "@typescript-eslint/eslint-plugin": "^8",
+        "@typescript-eslint/parser": "^8",
+        "all-contributors-cli": "^6.26.1",
+        "clone": "^2.1.2",
+        "constructs": "^10.0.0",
+        "eslint": "^9",
+        "eslint-config-prettier": "^8.10.0",
+        "eslint-import-resolver-typescript": "^3.10.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-unicorn": "^56.0.1",
+        "fast-check": "^3.23.2",
+        "glob": "^10.4.5",
+        "jest": "^29.7.0",
+        "jsii-1.x": "npm:jsii@1",
+        "lockfile": "^1.0.4",
+        "npm": "^9.9.4",
+        "npm-check-updates": "^16",
+        "prettier": "^2.8.8",
+        "projen": "^0.91.18",
+        "tar": "^6.2.1",
+        "ts-jest": "^29.3.0",
+        "ts-node": "^10.9.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      }
+    },
+    "../node_modules/.pnpm/publib@0.2.965/node_modules/publib": {
+      "version": "0.2.965",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-codeartifact": "^3.777.0",
+        "@aws-sdk/credential-providers": "^3.778.0",
+        "@aws-sdk/types": "^3.775.0",
+        "@types/fs-extra": "^8.0.0",
+        "fs-extra": "^8.0.0",
+        "glob": "10.0.0",
+        "p-queue": "6",
+        "shlex": "^2.1.2",
+        "yargs": "^17"
+      },
+      "bin": {
+        "jsii-release": "bin/jsii-release-shim",
+        "jsii-release-ca": "bin/jsii-release-shim",
+        "jsii-release-golang": "bin/jsii-release-shim",
+        "jsii-release-maven": "bin/jsii-release-shim",
+        "jsii-release-npm": "bin/jsii-release-shim",
+        "jsii-release-nuget": "bin/jsii-release-shim",
+        "jsii-release-pypi": "bin/jsii-release-shim",
+        "jsii-release-shim": "bin/jsii-release-shim",
+        "publib": "bin/publib",
+        "publib-ca": "bin/publib-ca",
+        "publib-golang": "bin/publib-golang",
+        "publib-maven": "bin/publib-maven",
+        "publib-npm": "bin/publib-npm",
+        "publib-nuget": "bin/publib-nuget",
+        "publib-pypi": "bin/publib-pypi"
+      },
+      "devDependencies": {
+        "@aws-sdk/client-sts": "^3.777.0",
+        "@types/glob": "^8.1.0",
+        "@types/jest": "^27.5.2",
+        "@types/node": "^18",
+        "@types/yargs": "^17",
+        "@typescript-eslint/eslint-plugin": "^7",
+        "@typescript-eslint/parser": "^7",
+        "cdklabs-projen-project-types": "^0.1.204",
+        "commit-and-tag-version": "^12",
+        "constructs": "^10.0.0",
+        "eslint": "^8",
+        "eslint-import-resolver-typescript": "^2.7.1",
+        "eslint-plugin-import": "^2.31.0",
+        "jest": "^27.5.1",
+        "jest-junit": "^15",
+        "projen": "^0.87.4",
+        "ts-jest": "^27.1.5",
+        "ts-node": "^10.9.2",
+        "typescript": "~4.9.5"
+      }
+    },
+    "../node_modules/.pnpm/typedoc-plugin-markdown@4.6.2_typedoc@0.28.2_typescript@5.8.3_/node_modules/typedoc-plugin-markdown": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "typedoc": "0.28.x"
+      }
+    },
+    "../node_modules/.pnpm/typedoc@0.28.2_typescript@5.8.3/node_modules/typedoc": {
+      "version": "0.28.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.2.2",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.0",
+        "minimatch": "^9.0.5",
+        "yaml": "^2.7.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.24.0",
+        "@types/lunr": "^2.3.7",
+        "@types/markdown-it": "^14.1.2",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "18",
+        "@typestrong/fs-fixture-builder": "github:TypeStrong/fs-fixture-builder#34113409e3a171e68ce5e2b55461ef5c35591cfe",
+        "c8": "^10.1.3",
+        "dprint": "^0.49.1",
+        "esbuild": "^0.25.2",
+        "eslint": "^9.24.0",
+        "mocha": "^11.1.0",
+        "puppeteer": "^24.6.0",
+        "semver": "^7.7.1",
+        "tsx": "^4.19.3",
+        "typescript": "5.8.3",
+        "typescript-eslint": "^8.29.0"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.236",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.236.tgz",
+      "integrity": "sha512-BjqQVGYsVuS4VXdrezDapSd6P7soEdWJoXl1S8X7l0uLtVX9WvpmCylZKOJDrJblK5MNe1Vq9wUI91LBzzOi8A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/aws-lambda-python-alpha": {
+      "version": "2.195.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.195.0-alpha.0.tgz",
+      "integrity": "sha512-PVEklq84j2eBeOzLewEGG3/KOicsZj6NxFfyVICBnuZnWlk58SSETX0VmgZ+CWKLJKZJx84rqowvtSZsYHiw9Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.195.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "41.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz",
+      "integrity": "sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/aws-cdk": {
+      "resolved": "../node_modules/.pnpm/aws-cdk@2.1006.0/node_modules/aws-cdk",
+      "link": true
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.195.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.195.0.tgz",
+      "integrity": "sha512-AYLysgSjSnSjkal/AmR86DqvOVqy0VjeWmXR+ucIIGSOzJsevsYuNWCeVnf4v9x+vd2ysVcO8fXndG426vGZ/w==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml",
+        "mime-types"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.229",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^41.2.0",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.0",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.1",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.17.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.6",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "resolved": "../node_modules/.pnpm/constructs@10.4.2/node_modules/constructs",
+      "link": true
+    },
+    "node_modules/jsii": {
+      "resolved": "../node_modules/.pnpm/jsii@5.8.3/node_modules/jsii",
+      "link": true
+    },
+    "node_modules/jsii-pacmak": {
+      "resolved": "../node_modules/.pnpm/jsii-pacmak@1.110.0_jsii-rosetta@5.8.0/node_modules/jsii-pacmak",
+      "link": true
+    },
+    "node_modules/publib": {
+      "resolved": "../node_modules/.pnpm/publib@0.2.965/node_modules/publib",
+      "link": true
+    },
+    "node_modules/typedoc": {
+      "resolved": "../node_modules/.pnpm/typedoc@0.28.2_typescript@5.8.3/node_modules/typedoc",
+      "link": true
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "resolved": "../node_modules/.pnpm/typedoc-plugin-markdown@4.6.2_typedoc@0.28.2_typescript@5.8.3_/node_modules/typedoc-plugin-markdown",
+      "link": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/package.json
+++ b/packages/package.json
@@ -23,7 +23,9 @@
   },
   "devDependencies": {
     "aws-cdk": "^2.1006.0",
-    "aws-cdk-lib": "2.183.0",
+    "aws-cdk-lib": "2.195.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.195.0-alpha.0",
+    "@types/node": "^22.13.10",
     "constructs": "10.4.2",
     "jsii": "^5.8.3",
     "jsii-pacmak": "^1.110.0",

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -5,6 +5,7 @@
     "inlineSources": true,
     "alwaysStrict": true,
     "declaration": true,
+    "esModuleInterop": true,
     "incremental": true,
     "lib": [
       "es2020"
@@ -15,8 +16,8 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
@@ -25,7 +26,10 @@
     "stripInternal": false,
     "target": "es2020",
     "composite": false,
-    "tsBuildInfoFile": "tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "tsconfig.tsbuildinfo",
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
   },
   "include": [
     "**/*.ts"

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -11,5 +11,11 @@ export const accountIdAlias: Record<StageName, string> = {
 };
 
 export function resolveStageName(): StageName {
-    return Object.entries(accountIdAlias).find(([_, value]) => value === cdk.Aws.ACCOUNT_ID)?.[0] as StageName;
+    const match = Object.entries(accountIdAlias).find(([_, value]) => value === cdk.Aws.ACCOUNT_ID)
+
+    if (!match) {
+        throw new Error(`Account ID ${cdk.Aws.ACCOUNT_ID} not found in accountIdAlias`);
+    }
+
+    return match[0] as StageName;
 }

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,1 +1,15 @@
+import * as cdk from "aws-cdk-lib";
+
 export type StageName = "BETA" | "GAMMA" | "PROD";
+
+export const region = 'ap-southeast-2';
+
+export const accountIdAlias: Record<StageName, string> = {
+  BETA: '843407916570', // umccr_development
+  GAMMA: '455634345446', // umccr_staging
+  PROD: '472057503814', // umccr_production
+};
+
+export function resolveStageName(): StageName {
+    return Object.entries(accountIdAlias).find(([_, value]) => value === cdk.Aws.ACCOUNT_ID)?.[0] as StageName;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,12 +33,18 @@ importers:
   packages:
 
     devDependencies:
+      '@aws-cdk/aws-lambda-python-alpha':
+        specifier: 2.195.0-alpha.0
+        version: 2.195.0-alpha.0(aws-cdk-lib@2.195.0(constructs@10.4.2))(constructs@10.4.2)
+      '@types/node':
+        specifier: ^22.13.10
+        version: 22.13.14
       aws-cdk:
         specifier: ^2.1006.0
         version: 2.1006.0
       aws-cdk-lib:
-        specifier: 2.183.0
-        version: 2.183.0(constructs@10.4.2)
+        specifier: 2.195.0
+        version: 2.195.0(constructs@10.4.2)
       constructs:
         specifier: 10.4.2
         version: 10.4.2
@@ -66,8 +72,22 @@ packages:
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.0':
     resolution: {integrity: sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==}
 
+  '@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0':
+    resolution: {integrity: sha512-PVEklq84j2eBeOzLewEGG3/KOicsZj6NxFfyVICBnuZnWlk58SSETX0VmgZ+CWKLJKZJx84rqowvtSZsYHiw9Q==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      aws-cdk-lib: ^2.195.0
+      constructs: ^10.0.0
+
   '@aws-cdk/cloud-assembly-schema@40.7.0':
     resolution: {integrity: sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==}
+    engines: {node: '>= 14.15.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
+
+  '@aws-cdk/cloud-assembly-schema@41.2.0':
+    resolution: {integrity: sha512-JaulVS6z9y5+u4jNmoWbHZRs9uGOnmn/ktXygNWKNu1k6lF3ad4so3s18eRu15XCbUIomxN9WPYT6Ehh7hzONw==}
     engines: {node: '>= 14.15.0'}
     bundledDependencies:
       - jsonschema
@@ -440,6 +460,24 @@ packages:
 
   aws-cdk-lib@2.183.0:
     resolution: {integrity: sha512-xwdDMm7qKBgN+dRjn8XxwS0YDRFM9JnUavFWM2bzaOzFeaBCiwFMrG0xLZaZs6GBImV804/jj8PnjmbOCsDZdw==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      constructs: ^10.0.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  aws-cdk-lib@2.195.0:
+    resolution: {integrity: sha512-AYLysgSjSnSjkal/AmR86DqvOVqy0VjeWmXR+ucIIGSOzJsevsYuNWCeVnf4v9x+vd2ysVcO8fXndG426vGZ/w==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       constructs: ^10.0.0
@@ -923,7 +961,14 @@ snapshots:
 
   '@aws-cdk/asset-node-proxy-agent-v6@2.1.0': {}
 
+  '@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.195.0(constructs@10.4.2))(constructs@10.4.2)':
+    dependencies:
+      aws-cdk-lib: 2.195.0(constructs@10.4.2)
+      constructs: 10.4.2
+
   '@aws-cdk/cloud-assembly-schema@40.7.0': {}
+
+  '@aws-cdk/cloud-assembly-schema@41.2.0': {}
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -1710,6 +1755,13 @@ snapshots:
       '@aws-cdk/asset-awscli-v1': 2.2.229
       '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
       '@aws-cdk/cloud-assembly-schema': 40.7.0
+      constructs: 10.4.2
+
+  aws-cdk-lib@2.195.0(constructs@10.4.2):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.229
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
+      '@aws-cdk/cloud-assembly-schema': 41.2.0
       constructs: 10.4.2
 
   aws-cdk@2.1006.0:


### PR DESCRIPTION
Common DynamoDb constructs used throughout our Orcabus repository, 

Can choose from either a simple 'primary key' database (with 'id' as the primary key),

Or a sort key with 'id' as the primary key and 'id_type' as the sort key