### PR TITLE
Rename ECS Task Construct, update tsconfig validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,14 @@ pnpm build
 pnpm package
 pnpm publish
 ```
+
+Alternative, you may push a new release to the `main` branch. This will trigger the GitHub Action to publish the package automatically.
+
+i.e
+
+```shell
+git pull origin main
+git checkout main
+
+gh release create 0.0.10-alpha.0 --title '0.0.10-alpha.0 release!' --notes-file 'release-notes.md'
+```

--- a/packages/ecs/index.ts
+++ b/packages/ecs/index.ts
@@ -76,7 +76,7 @@ export interface FargateEcsTaskConstructProps {
     readonly dockerPath: string
 }
 
-export class EcsTaskConstruct extends Construct {
+export class EcsFargateTaskConstruct extends Construct {
     public readonly cluster: ecs.ICluster
     public readonly taskDefinition: ecs.FargateTaskDefinition
     public readonly securityGroup: ec2.ISecurityGroup

--- a/packages/package.json
+++ b/packages/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "types": "index.d.ts",
   "scripts": {
-    "build": "jsii --tsconfig tsconfig.json",
+    "build": "jsii --tsconfig tsconfig.json --validate-tsconfig minimal",
     "build:watch": "jsii --watch",
     "package": "jsii-pacmak",
     "generate-docs": "typedoc --plugin typedoc-plugin-markdown --out ./docs"


### PR DESCRIPTION
jsii doesn't allow typeRoots in tsconfig when in 'strict' mode

Also added in gh release logic into readme