### PR TITLE
Add ICAv2 Access token secret id access to PythonUvFunction

### DIFF
--- a/packages/lambda/config.ts
+++ b/packages/lambda/config.ts
@@ -3,6 +3,7 @@ import {accountIdAlias, region, StageName} from "../utils";
 export const DEFAULT_ORCABUS_TOKEN_SECRET_ID =  'orcabus/token-service-jwt'
 export const DEFAULT_HOSTNAME_SSM_PARAMETER = '/hosted_zone/umccr/name'
 
+
 export const MART_ENV_VARS = {
     athenaWorkgroupName: 'orcahouse',
     athenaDatasourceName: 'orcavault',
@@ -16,3 +17,9 @@ export const MART_S3_BUCKET: Record<StageName, string> = {
 }
 export const MART_S3_PREFIX = 'athena-query-results/'
 export const MART_LAMBDA_FUNCTION_NAME = 'orcavault'
+
+export const DEFAULT_ICAV2_ACCESS_TOKEN_SECRET_ID: Record<StageName, string> = {
+  BETA: 'ICAv2JWTKey-umccr-prod-service-dev', // pragma: allowlist secret
+  GAMMA: 'ICAv2JWTKey-umccr-prod-service-staging', // pragma: allowlist secret
+  PROD: 'ICAv2JWTKey-umccr-prod-service-production', // pragma: allowlist secret
+};

--- a/packages/lambda/layers/icav2_tools/pyproject.toml
+++ b/packages/lambda/layers/icav2_tools/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "icav2_tools"
+version = "1.0.0"
+description = "Useful layer for python lambdas that use ICAv2, smart-collection of the ICAv2 access token"
+license = "GPL-3.0-or-later"
+authors = [
+    "Alexis Lucattini"
+]
+homepage = "https://github.com/orcabus/platform-cdk-constructs"
+repository = "https://github.com/orcabus/platform-cdk-constructs"
+
+[tool.poetry.dependencies]
+python = "^3.12, <3.13"
+
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0.0"  # For testing only
+# For typehinting only, not required at runtime
+mypy-boto3-secretsmanager = "^1.34"

--- a/packages/lambda/layers/icav2_tools/src/icav2_tools/__init__.py
+++ b/packages/lambda/layers/icav2_tools/src/icav2_tools/__init__.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+from .aws_helpers import get_icav2_access_token
+from os import environ
+from .globals import ICAV2_BASE_URL
+
+
+def set_icav2_env_vars():
+    """
+    Set the environment variables for the ICAV2 API
+    :return:
+    """
+    environ["ICAV2_ACCESS_TOKEN"] = get_icav2_access_token()
+    environ["ICAV2_BASE_URL"] = ICAV2_BASE_URL
+
+
+__all__ = [
+    "set_icav2_env_vars"
+]

--- a/packages/lambda/layers/icav2_tools/src/icav2_tools/aws_helpers.py
+++ b/packages/lambda/layers/icav2_tools/src/icav2_tools/aws_helpers.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+# Standard imports
+import typing
+from typing import Optional
+import boto3
+import json
+from os import environ
+import urllib3
+from urllib.parse import urlunparse
+
+
+# Type hinting
+if typing.TYPE_CHECKING:
+    from mypy_boto3_secretsmanager import SecretsManagerClient
+    from mypy_boto3_ssm import SSMClient
+
+# Set globals
+from .globals import ICAV2_BASE_URL
+
+http = urllib3.PoolManager()
+
+LOCAL_HTTP_CACHE_PORT = 2773
+PARAMETER_URL = '/systemsmanager/parameters/get/'
+SECRETS_URL = '/secretsmanager/get/'
+
+def retrieve_extension_value(url, query):
+    url = str(urlunparse((
+        'http', f'localhost:{LOCAL_HTTP_CACHE_PORT}',
+        url, None,
+        "&".join(list(map(
+            lambda kv: f"{kv[0]}={kv[1]}",
+            query.items()
+        ))), None
+    )))
+    headers = {
+        "X-Aws-Parameters-Secrets-Token": environ.get('AWS_SESSION_TOKEN')
+    }
+    response = http.request("GET", url, headers=headers)
+    response = json.loads(response.data)
+    return response
+
+
+def get_ssm_value_from_cache(parameter_name: str) -> Optional[str]:
+    try:
+        return retrieve_extension_value(
+            PARAMETER_URL,
+            {
+                "name": parameter_name,
+            }
+        )['Parameter']['Value']
+    except Exception as e:
+        print("Got an exception while trying to get ssm value from cache")
+        print(e)
+        return None
+
+
+def get_secret_value_from_cache(secret_id: str) -> Optional[str]:
+    try:
+        return retrieve_extension_value(
+            SECRETS_URL,
+            {
+                "secretId": secret_id,
+            }
+        )['SecretString']
+    except Exception as e:
+        print("Got an exception while trying to get secret value from cache")
+        print(e)
+        return None
+
+def get_secretsmanager_client() -> 'SecretsManagerClient':
+    return boto3.client('secretsmanager')
+
+
+def get_ssm_client() -> 'SSMClient':
+    return boto3.client('ssm')
+
+
+def get_secret_value(secret_id) -> str:
+    """
+    Collect the secret value
+    :param secret_id:
+    :return:
+    """
+    secret_value_cached = get_secret_value_from_cache(secret_id)
+    if secret_value_cached is not None:
+        return secret_value_cached
+
+    # Get the boto3 response
+    get_secret_value_response = get_secretsmanager_client().get_secret_value(SecretId=secret_id)
+
+    return get_secret_value_response['SecretString']
+
+
+def get_ssm_value(parameter_name) -> str:
+    """
+    Collect the parameter from SSM
+    :param parameter_name:
+    :return:
+    """
+    ssm_parameter_cached = get_ssm_value_from_cache(parameter_name)
+    if ssm_parameter_cached is not None:
+        return ssm_parameter_cached
+
+    # Get the boto3 response
+    get_ssm_parameter_response = get_ssm_client().get_parameter(Name=parameter_name)
+
+    return get_ssm_parameter_response['Parameter']['Value']
+
+
+def get_icav2_access_token() -> str:
+    """
+    From the AWS Secrets Manager, retrieve the OrcaBus token.
+    :return:
+    """
+    return get_secret_value(environ.get("ICAV2_ACCESS_TOKEN_SECRET_ID"))

--- a/packages/lambda/layers/icav2_tools/src/icav2_tools/globals.py
+++ b/packages/lambda/layers/icav2_tools/src/icav2_tools/globals.py
@@ -1,0 +1,2 @@
+# Set ICAV2 Base url
+ICAV2_BASE_URL = "https://ica.illumina.com/ica/rest"


### PR DESCRIPTION
ICAv2 Access Token Secret ID access added as an optional layer 
with the env var ICAV2_ACCESS_TOKEN_SECRET_ID as the path to the secret name.

Added compatibility to the ParamsAndSecrets extension so caching of the token is also functional.

Means inside the handler definition user only has to perform the following to get ICAV2_ACCESS_TOKEN, and ICAV2_BASE_URL into the environment.  

This allows other installations, such as wrapica or libica to easily create a configuration session.

```

from icav2_tools import set_icav2_env_vars

def handler(event, context):
    set_icav2_env_vars() 

```