### PR TITLE
feat: add missing filemanager prefix export

### DIFF
--- a/packages/docs/@orcabus/namespaces/apigateway/variables/CERTIFICATE_ARN_PARAMETER_NAME.md
+++ b/packages/docs/@orcabus/namespaces/apigateway/variables/CERTIFICATE_ARN_PARAMETER_NAME.md
@@ -1,0 +1,11 @@
+[**@orcabus/platform-cdk-constructs**](../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../README.md) / [apigateway](../README.md) / CERTIFICATE\_ARN\_PARAMETER\_NAME
+
+# Variable: CERTIFICATE\_ARN\_PARAMETER\_NAME
+
+> `const` **CERTIFICATE\_ARN\_PARAMETER\_NAME**: `"/umccr/certificate_arn"` = `"/umccr/certificate_arn"`
+
+Defined in: [packages/api-gateway/config.ts:34](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/config.ts#L34)

--- a/packages/docs/@orcabus/namespaces/apigateway/variables/HOSTED_ZONE_DOMAIN_PARAMETER_NAME.md
+++ b/packages/docs/@orcabus/namespaces/apigateway/variables/HOSTED_ZONE_DOMAIN_PARAMETER_NAME.md
@@ -1,0 +1,11 @@
+[**@orcabus/platform-cdk-constructs**](../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../README.md) / [apigateway](../README.md) / HOSTED\_ZONE\_DOMAIN\_PARAMETER\_NAME
+
+# Variable: HOSTED\_ZONE\_DOMAIN\_PARAMETER\_NAME
+
+> `const` **HOSTED\_ZONE\_DOMAIN\_PARAMETER\_NAME**: `"/hosted_zone/umccr/name"` = `"/hosted_zone/umccr/name"`
+
+Defined in: [packages/api-gateway/config.ts:35](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/config.ts#L35)

--- a/packages/docs/@orcabus/namespaces/apigateway/variables/HOSTED_ZONE_ID_PARAMETER_NAME.md
+++ b/packages/docs/@orcabus/namespaces/apigateway/variables/HOSTED_ZONE_ID_PARAMETER_NAME.md
@@ -1,0 +1,11 @@
+[**@orcabus/platform-cdk-constructs**](../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../README.md) / [apigateway](../README.md) / HOSTED\_ZONE\_ID\_PARAMETER\_NAME
+
+# Variable: HOSTED\_ZONE\_ID\_PARAMETER\_NAME
+
+> `const` **HOSTED\_ZONE\_ID\_PARAMETER\_NAME**: `"/hosted_zone/umccr/id"` = `"/hosted_zone/umccr/id"`
+
+Defined in: [packages/api-gateway/config.ts:36](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/config.ts#L36)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/README.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/README.md
@@ -11,6 +11,7 @@
 - [accessKeySecretArn](variables/accessKeySecretArn.md)
 - [fileManagerBuckets](variables/fileManagerBuckets.md)
 - [fileManagerCacheBuckets](variables/fileManagerCacheBuckets.md)
+- [fileManagerDomainPrefix](variables/fileManagerDomainPrefix.md)
 - [fileManagerIngestRoleName](variables/fileManagerIngestRoleName.md)
 - [fileManagerPresignUser](variables/fileManagerPresignUser.md)
 - [fileManagerPresignUserSecret](variables/fileManagerPresignUserSecret.md)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/fileManagerDomainPrefix.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/fileManagerDomainPrefix.md
@@ -1,0 +1,11 @@
+[**@orcabus/platform-cdk-constructs**](../../../../../../README.md)
+
+***
+
+[@orcabus/platform-cdk-constructs](../../../../../../README.md) / [sharedConfig](../../../README.md) / [fileManager](../README.md) / fileManagerDomainPrefix
+
+# Variable: fileManagerDomainPrefix
+
+> `const` **fileManagerDomainPrefix**: `"file"` = `"file"`
+
+Defined in: [packages/shared-config/file-manager.ts:51](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L51)

--- a/packages/shared-config/file-manager.ts
+++ b/packages/shared-config/file-manager.ts
@@ -2,7 +2,7 @@
  * Shared config for the FileManager.
  */
 
-import { StageName, validateSecretName } from "../utils/index";
+import { StageName, validateSecretName } from "../utils";
 import {
   BETA_ENVIRONMENT,
   GAMMA_ENVIRONMENT,
@@ -10,18 +10,18 @@ import {
 } from "../deployment-stack-pipeline";
 
 export const fileManagerBuckets: Record<StageName, string[]> = {
-  ["BETA"]: [
+  BETA: [
     "umccr-temp-dev",
     `ntsm-fingerprints-${BETA_ENVIRONMENT.account}-ap-southeast-2`,
     `data-sharing-artifacts-${BETA_ENVIRONMENT.account}-ap-southeast-2`,
     "filemanager-inventory-test",
   ],
-  ["GAMMA"]: [
+  GAMMA: [
     "umccr-temp-stg",
     `ntsm-fingerprints-${GAMMA_ENVIRONMENT.account}-ap-southeast-2`,
     `data-sharing-artifacts-${GAMMA_ENVIRONMENT.account}-ap-southeast-2`,
   ],
-  ["PROD"]: [
+  PROD: [
     "org.umccr.data.oncoanalyser",
     "archive-prod-analysis-503977275616-ap-southeast-2",
     "archive-prod-fastq-503977275616-ap-southeast-2",
@@ -32,19 +32,20 @@ export const fileManagerBuckets: Record<StageName, string[]> = {
 };
 
 export const fileManagerCacheBuckets: Record<StageName, string[]> = {
-  ["BETA"]: ["pipeline-dev-cache-503977275616-ap-southeast-2"],
-  ["GAMMA"]: ["pipeline-stg-cache-503977275616-ap-southeast-2"],
-  ["PROD"]: ["pipeline-prod-cache-503977275616-ap-southeast-2"],
+  BETA: ["pipeline-dev-cache-503977275616-ap-southeast-2"],
+  GAMMA: ["pipeline-stg-cache-503977275616-ap-southeast-2"],
+  PROD: ["pipeline-prod-cache-503977275616-ap-southeast-2"],
 };
 
 export const fileManagerPresignUserSecret = "orcabus/file-manager-presign-user"; // pragma: allowlist secret
 export const accessKeySecretArn: Record<StageName, string> = {
-  ["BETA"]: `arn:aws:secretsmanager:${BETA_ENVIRONMENT.region}:${BETA_ENVIRONMENT.account}:secret:${fileManagerPresignUserSecret}`,
-  ["GAMMA"]: `arn:aws:secretsmanager:${GAMMA_ENVIRONMENT.region}:${GAMMA_ENVIRONMENT.account}:secret:${fileManagerPresignUserSecret}`,
-  ["PROD"]: `arn:aws:secretsmanager:${PROD_ENVIRONMENT.region}:${PROD_ENVIRONMENT.account}:secret:${fileManagerPresignUserSecret}`,
+  BETA: `arn:aws:secretsmanager:${BETA_ENVIRONMENT.region}:${BETA_ENVIRONMENT.account}:secret:${fileManagerPresignUserSecret}`,
+  GAMMA: `arn:aws:secretsmanager:${GAMMA_ENVIRONMENT.region}:${GAMMA_ENVIRONMENT.account}:secret:${fileManagerPresignUserSecret}`,
+  PROD: `arn:aws:secretsmanager:${PROD_ENVIRONMENT.region}:${PROD_ENVIRONMENT.account}:secret:${fileManagerPresignUserSecret}`,
 };
 
 export const fileManagerIngestRoleName = "orcabus-file-manager-ingest-role";
 validateSecretName(fileManagerPresignUserSecret);
 
 export const fileManagerPresignUser = "orcabus-file-manager-presign-user"; // pragma: allowlist secret
+export const fileManagerDomainPrefix = "file";


### PR DESCRIPTION
### Changes
* Add the filemanager domain name prefix as an export in the shared config