### PR TITLE
ECS updates

### DIFF
--- a/packages/docs/@orcabus/namespaces/ecs/classes/EcsFargateTaskConstruct.md
+++ b/packages/docs/@orcabus/namespaces/ecs/classes/EcsFargateTaskConstruct.md
@@ -6,7 +6,7 @@
 
 # Class: EcsFargateTaskConstruct
 
-Defined in: [packages/ecs/index.ts:79](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L79)
+Defined in: [packages/ecs/index.ts:82](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L82)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [packages/ecs/index.ts:79](https://github.com/OrcaBus/platform-cdk-c
 
 > **new EcsFargateTaskConstruct**(`scope`, `id`, `props`): `EcsFargateTaskConstruct`
 
-Defined in: [packages/ecs/index.ts:85](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L85)
+Defined in: [packages/ecs/index.ts:88](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L88)
 
 #### Parameters
 
@@ -48,7 +48,7 @@ Defined in: [packages/ecs/index.ts:85](https://github.com/OrcaBus/platform-cdk-c
 
 > `readonly` **cluster**: `ICluster`
 
-Defined in: [packages/ecs/index.ts:80](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L80)
+Defined in: [packages/ecs/index.ts:83](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L83)
 
 ***
 
@@ -56,7 +56,7 @@ Defined in: [packages/ecs/index.ts:80](https://github.com/OrcaBus/platform-cdk-c
 
 > `readonly` **containerDefinition**: `ContainerDefinition`
 
-Defined in: [packages/ecs/index.ts:83](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L83)
+Defined in: [packages/ecs/index.ts:86](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L86)
 
 ***
 
@@ -78,7 +78,7 @@ The tree node.
 
 > `readonly` **securityGroup**: `ISecurityGroup`
 
-Defined in: [packages/ecs/index.ts:82](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L82)
+Defined in: [packages/ecs/index.ts:85](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L85)
 
 ***
 
@@ -86,7 +86,7 @@ Defined in: [packages/ecs/index.ts:82](https://github.com/OrcaBus/platform-cdk-c
 
 > `readonly` **taskDefinition**: `FargateTaskDefinition`
 
-Defined in: [packages/ecs/index.ts:81](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L81)
+Defined in: [packages/ecs/index.ts:84](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L84)
 
 ## Methods
 

--- a/packages/docs/@orcabus/namespaces/ecs/interfaces/FargateEcsTaskConstructProps.md
+++ b/packages/docs/@orcabus/namespaces/ecs/interfaces/FargateEcsTaskConstructProps.md
@@ -6,15 +6,15 @@
 
 # Interface: FargateEcsTaskConstructProps
 
-Defined in: [packages/ecs/index.ts:39](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L39)
+Defined in: [packages/ecs/index.ts:42](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L42)
 
 ## Properties
 
-### architecture
+### architecture?
 
-> `readonly` **architecture**: [`Architecture`](../type-aliases/Architecture.md)
+> `readonly` `optional` **architecture**: [`Architecture`](../type-aliases/Architecture.md)
 
-Defined in: [packages/ecs/index.ts:65](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L65)
+Defined in: [packages/ecs/index.ts:68](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L68)
 
 The architecture of the container. If not provided, the default is @DEFAULT_ARCHITECTURE.
 
@@ -24,7 +24,7 @@ The architecture of the container. If not provided, the default is @DEFAULT_ARCH
 
 > `readonly` **containerName**: `string`
 
-Defined in: [packages/ecs/index.ts:71](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L71)
+Defined in: [packages/ecs/index.ts:74](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L74)
 
 The name of the container. This is a required property
 
@@ -34,7 +34,7 @@ The name of the container. This is a required property
 
 > `readonly` **dockerPath**: `string`
 
-Defined in: [packages/ecs/index.ts:76](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L76)
+Defined in: [packages/ecs/index.ts:79](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L79)
 
 The path to the Dockerfile. This is a required property
 
@@ -44,7 +44,7 @@ The path to the Dockerfile. This is a required property
 
 > `readonly` **memoryLimitGiB**: `number`
 
-Defined in: [packages/ecs/index.ts:60](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L60)
+Defined in: [packages/ecs/index.ts:63](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L63)
 
 The memory limit in GiB. If not provided, the default is @DEFAULT_MEMORY_GB.
 The memory limit must be between 0.5 and 120 GiB.
@@ -56,17 +56,17 @@ But please note that the memory limit varies depending on the number of CPUs, pl
 
 > `readonly` **nCpus**: `number`
 
-Defined in: [packages/ecs/index.ts:53](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L53)
+Defined in: [packages/ecs/index.ts:56](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L56)
 
 The number of CPUs to use, between 0.25 and 16. If not provided, the default is @DEFAULT_VCPUS.
 
 ***
 
-### runtimePlatform
+### runtimePlatform?
 
-> `readonly` **runtimePlatform**: `CpuArchitecture`
+> `readonly` `optional` **runtimePlatform**: `CpuArchitecture`
 
-Defined in: [packages/ecs/index.ts:48](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L48)
+Defined in: [packages/ecs/index.ts:51](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L51)
 
 The runtime CPU architecture, either X86_64 or ARM64. If not provided, the default is @DEFAULT_ARCHITECTURE.
 
@@ -76,6 +76,6 @@ The runtime CPU architecture, either X86_64 or ARM64. If not provided, the defau
 
 > `readonly` `optional` **vpcName**: `string`
 
-Defined in: [packages/ecs/index.ts:43](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L43)
+Defined in: [packages/ecs/index.ts:46](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L46)
 
 The name of the VPC to use. If not provided, the @DEFAULT_MAIN_VPC_NAME will be used.

--- a/packages/docs/@orcabus/namespaces/ecs/type-aliases/Architecture.md
+++ b/packages/docs/@orcabus/namespaces/ecs/type-aliases/Architecture.md
@@ -8,4 +8,4 @@
 
 > **Architecture** = `"X86_64"` \| `"ARM64"`
 
-Defined in: [packages/ecs/index.ts:27](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L27)
+Defined in: [packages/ecs/index.ts:30](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L30)

--- a/packages/docs/@orcabus/namespaces/ecs/variables/CPU_ARCHITECTURE_MAP.md
+++ b/packages/docs/@orcabus/namespaces/ecs/variables/CPU_ARCHITECTURE_MAP.md
@@ -8,4 +8,4 @@
 
 > `const` **CPU\_ARCHITECTURE\_MAP**: `Record`\<[`Architecture`](../type-aliases/Architecture.md), `ecs.CpuArchitecture`\>
 
-Defined in: [packages/ecs/index.ts:29](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L29)
+Defined in: [packages/ecs/index.ts:32](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L32)

--- a/packages/docs/@orcabus/namespaces/ecs/variables/LAMBDA_ARCHITECTURE_MAP.md
+++ b/packages/docs/@orcabus/namespaces/ecs/variables/LAMBDA_ARCHITECTURE_MAP.md
@@ -8,4 +8,4 @@
 
 > `const` **LAMBDA\_ARCHITECTURE\_MAP**: `Record`\<[`Architecture`](../type-aliases/Architecture.md), `lambda.Architecture`\>
 
-Defined in: [packages/ecs/index.ts:34](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L34)
+Defined in: [packages/ecs/index.ts:37](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/ecs/index.ts#L37)

--- a/packages/ecs/config.ts
+++ b/packages/ecs/config.ts
@@ -1,6 +1,10 @@
+/**
+ * @deprecated, use VPC_NAME from shared-config instead
+ */
 export const DEFAULT_MAIN_VPC_NAME = 'main-vpc'
 
 export const DEFAULT_MEMORY_GB = 1
 export const DEFAULT_VCPUS = 2
+
 
 export const DEFAULT_ARCHITECTURE = 'ARM64'

--- a/packages/ecs/index.ts
+++ b/packages/ecs/index.ts
@@ -1,11 +1,14 @@
 import {Construct} from "constructs";
-import {DEFAULT_ARCHITECTURE, DEFAULT_MAIN_VPC_NAME, DEFAULT_MEMORY_GB, DEFAULT_VCPUS} from "./config";
+import {DEFAULT_ARCHITECTURE, DEFAULT_MEMORY_GB, DEFAULT_VCPUS} from "./config";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import {ContainerInsights} from "aws-cdk-lib/aws-ecs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as ecrAssets from "aws-cdk-lib/aws-ecr-assets";
+import * as iam from "aws-cdk-lib/aws-iam";
 import {RetentionDays} from "aws-cdk-lib/aws-logs";
+import {VPC_NAME} from "../shared-config/networking";
+import {ManagedPolicy} from "aws-cdk-lib/aws-iam";
 
 // Memory and CPU limits for Fargate tasks
 /*
@@ -45,7 +48,7 @@ export interface FargateEcsTaskConstructProps {
     /**
      * The runtime CPU architecture, either X86_64 or ARM64. If not provided, the default is @DEFAULT_ARCHITECTURE.
      */
-    readonly runtimePlatform: ecs.CpuArchitecture
+    readonly runtimePlatform?: ecs.CpuArchitecture
 
     /**
      * The number of CPUs to use, between 0.25 and 16. If not provided, the default is @DEFAULT_VCPUS.
@@ -62,7 +65,7 @@ export interface FargateEcsTaskConstructProps {
     /**
      * The architecture of the container. If not provided, the default is @DEFAULT_ARCHITECTURE.
      */
-    readonly architecture: Architecture
+    readonly architecture?: Architecture
 
 
     /**
@@ -91,7 +94,7 @@ export class EcsFargateTaskConstruct extends Construct {
         // Set up the main vpc
         const mainVpc = ec2.Vpc.fromLookup(
             this, 'MainVpc', {
-                vpcName: props.vpcName ?? DEFAULT_MAIN_VPC_NAME
+                vpcName: props.vpcName ?? VPC_NAME
             }
         )
 
@@ -102,13 +105,22 @@ export class EcsFargateTaskConstruct extends Construct {
             containerInsightsV2: ContainerInsights.ENABLED
         })
 
+        // Allow the task definition role ecr access to the guardduty agent
+        // https://docs.aws.amazon.com/guardduty/latest/ug/prereq-runtime-monitoring-ecs-support.html#before-enable-runtime-monitoring-ecs
+        // Which is in another account - 005257825471.dkr.ecr.ap-southeast-2.amazonaws.com/aws-guardduty-agent-fargate
+        const taskExecutionRole = new iam.Role(this, `task-execution-role`, {
+          assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com'),
+          managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy')],
+        })
+
         // Set up the Fargate task definition
         this.taskDefinition = new ecs.FargateTaskDefinition(this, 'FargateTaskDef', {
             cpu: (props.nCpus ?? DEFAULT_VCPUS) * 1024,
             memoryLimitMiB: props.memoryLimitGiB ?? (DEFAULT_MEMORY_GB) * 1024,
             runtimePlatform: {
                 cpuArchitecture: props.runtimePlatform ?? CPU_ARCHITECTURE_MAP[architecture],
-            }
+            },
+            executionRole: taskExecutionRole
         })
 
         // Set up the security group


### PR DESCRIPTION
Add ECSTaskExecutionRolePolicy to the execution role of a task definition by default. 

This allows the AWS guard duty agent to run alongside any task