### PR TITLE
fix: formatArn should return a string

### DIFF
--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/slack/classes/SlackAlerts.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/slack/classes/SlackAlerts.md
@@ -24,7 +24,7 @@ A helper class to construct the arn for the slack SNS topic.
 
 ### formatArn()
 
-> `static` **formatArn**(`stack`): `Arn`
+> `static` **formatArn**(`stack`): `string`
 
 Defined in: [packages/shared-config/slack.ts:17](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/slack.ts#L17)
 
@@ -38,6 +38,6 @@ Format the ARN for the slack alerts SNS topic for the current stack.
 
 #### Returns
 
-`Arn`
+`string`
 
 Arn

--- a/packages/shared-config/slack.ts
+++ b/packages/shared-config/slack.ts
@@ -14,7 +14,7 @@ export class SlackAlerts {
    * @param stack
    * @returns Arn
    */
-  public static formatArn(stack: Stack): Arn {
+  public static formatArn(stack: Stack): string {
     return Arn.format(
       {
         service: "sns",


### PR DESCRIPTION
### Changes
* The `formatArn` function should return a string rather than the `Arn` class.

Related to #66.