### PR TITLE
fix: treat missing data points as missing

### DIFF
--- a/packages/docs/@orcabus/namespaces/monitoredQueue/classes/MonitoredQueue.md
+++ b/packages/docs/@orcabus/namespaces/monitoredQueue/classes/MonitoredQueue.md
@@ -6,7 +6,7 @@
 
 # Class: MonitoredQueue
 
-Defined in: [packages/monitored-queue/index.ts:57](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L57)
+Defined in: [packages/monitored-queue/index.ts:53](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L53)
 
 A construct that defines an SQS queue, along with a DLQ and CloudWatch alarms that can notify an
 SNS topic.
@@ -21,7 +21,7 @@ SNS topic.
 
 > **new MonitoredQueue**(`scope`, `id`, `props`): `MonitoredQueue`
 
-Defined in: [packages/monitored-queue/index.ts:62](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L62)
+Defined in: [packages/monitored-queue/index.ts:58](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L58)
 
 #### Parameters
 
@@ -51,7 +51,7 @@ Defined in: [packages/monitored-queue/index.ts:62](https://github.com/OrcaBus/pl
 
 > `readonly` **alarm**: `Alarm`
 
-Defined in: [packages/monitored-queue/index.ts:60](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L60)
+Defined in: [packages/monitored-queue/index.ts:56](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L56)
 
 ***
 
@@ -59,7 +59,7 @@ Defined in: [packages/monitored-queue/index.ts:60](https://github.com/OrcaBus/pl
 
 > `readonly` **deadLetterQueue**: `Queue`
 
-Defined in: [packages/monitored-queue/index.ts:59](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L59)
+Defined in: [packages/monitored-queue/index.ts:55](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L55)
 
 ***
 
@@ -81,7 +81,7 @@ The tree node.
 
 > `readonly` **queue**: `Queue`
 
-Defined in: [packages/monitored-queue/index.ts:58](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L58)
+Defined in: [packages/monitored-queue/index.ts:54](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L54)
 
 ## Accessors
 
@@ -91,7 +91,7 @@ Defined in: [packages/monitored-queue/index.ts:58](https://github.com/OrcaBus/pl
 
 > **get** **queueArn**(): `string`
 
-Defined in: [packages/monitored-queue/index.ts:98](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L98)
+Defined in: [packages/monitored-queue/index.ts:93](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L93)
 
 Get the SQS queue ARN.
 

--- a/packages/docs/@orcabus/namespaces/monitoredQueue/interfaces/MonitoredQueueProps.md
+++ b/packages/docs/@orcabus/namespaces/monitoredQueue/interfaces/MonitoredQueueProps.md
@@ -6,7 +6,7 @@
 
 # Interface: MonitoredQueueProps
 
-Defined in: [packages/monitored-queue/index.ts:15](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L15)
+Defined in: [packages/monitored-queue/index.ts:11](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L11)
 
 Properties for the monitored queue.
 
@@ -16,7 +16,7 @@ Properties for the monitored queue.
 
 > `readonly` `optional` **dlqProps**: [`QueueProps`](QueueProps.md)
 
-Defined in: [packages/monitored-queue/index.ts:23](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L23)
+Defined in: [packages/monitored-queue/index.ts:19](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L19)
 
 The props for the dead-letter SQS queue when a message fails.
 
@@ -26,7 +26,7 @@ The props for the dead-letter SQS queue when a message fails.
 
 > `readonly` `optional` **maxReceiveCount**: `number`
 
-Defined in: [packages/monitored-queue/index.ts:28](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L28)
+Defined in: [packages/monitored-queue/index.ts:24](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L24)
 
 The maximum number of times a message can be unsuccessfully received before
 pushing it to the DLQ. Defaults to 3.
@@ -37,7 +37,7 @@ pushing it to the DLQ. Defaults to 3.
 
 > `readonly` `optional` **queueProps**: [`QueueProps`](QueueProps.md)
 
-Defined in: [packages/monitored-queue/index.ts:19](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L19)
+Defined in: [packages/monitored-queue/index.ts:15](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L15)
 
 The props for the main SQS queue.
 
@@ -47,6 +47,6 @@ The props for the main SQS queue.
 
 > `readonly` `optional` **snsTopicArn**: `string`
 
-Defined in: [packages/monitored-queue/index.ts:32](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L32)
+Defined in: [packages/monitored-queue/index.ts:28](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L28)
 
 Send the alarm notification to the SNS topic with the ARN.

--- a/packages/docs/@orcabus/namespaces/monitoredQueue/interfaces/QueueProps.md
+++ b/packages/docs/@orcabus/namespaces/monitoredQueue/interfaces/QueueProps.md
@@ -6,7 +6,7 @@
 
 # Interface: QueueProps
 
-Defined in: [packages/monitored-queue/index.ts:38](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L38)
+Defined in: [packages/monitored-queue/index.ts:34](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L34)
 
 Properties for an SQS queue.
 
@@ -16,7 +16,7 @@ Properties for an SQS queue.
 
 > `readonly` `optional` **queueName**: `string`
 
-Defined in: [packages/monitored-queue/index.ts:42](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L42)
+Defined in: [packages/monitored-queue/index.ts:38](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L38)
 
 The name of the queue to construct. Defaults to the automatically generated name.
 
@@ -26,7 +26,7 @@ The name of the queue to construct. Defaults to the automatically generated name
 
 > `readonly` `optional` **removalPolicy**: `RemovalPolicy`
 
-Defined in: [packages/monitored-queue/index.ts:50](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L50)
+Defined in: [packages/monitored-queue/index.ts:46](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L46)
 
 The removal policy of the queue.
 
@@ -36,6 +36,6 @@ The removal policy of the queue.
 
 > `readonly` `optional` **retentionPeriod**: `Duration`
 
-Defined in: [packages/monitored-queue/index.ts:46](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L46)
+Defined in: [packages/monitored-queue/index.ts:42](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L42)
 
 How long messages stay in the queue.

--- a/packages/monitored-queue/index.ts
+++ b/packages/monitored-queue/index.ts
@@ -1,10 +1,6 @@
 import { Construct } from "constructs";
 import { Queue } from "aws-cdk-lib/aws-sqs";
-import {
-  Alarm,
-  ComparisonOperator,
-  TreatMissingData,
-} from "aws-cdk-lib/aws-cloudwatch";
+import { Alarm, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
 import { Duration, RemovalPolicy } from "aws-cdk-lib";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
@@ -78,7 +74,6 @@ export class MonitoredQueue extends Construct {
 
     this.alarm = new Alarm(this, "Alarm", {
       metric: this.deadLetterQueue.metricApproximateNumberOfMessagesVisible(),
-      treatMissingData: TreatMissingData.BREACHING,
       comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
       threshold: 0,
       evaluationPeriods: 1,


### PR DESCRIPTION
### Changes
* Treats missing data points as missing in the monitored queue to avoid false positives.