### PR TITLE
Added extra options  to job patch, no more fastq set queries for jobs

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/__init__.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/__init__.py
@@ -70,7 +70,7 @@ from .create_helpers import create_job
 from .query_helpers import (
     get_job_from_job_id,
     get_decompression_job_list,
-    get_job_list_for_fastq_set
+    get_job_list_for_fastq
 )
 
 # Update helpers
@@ -85,7 +85,7 @@ __all__ = [
     # Query helpers
     "get_job_from_job_id",
     "get_decompression_job_list",
-    "get_job_list_for_fastq_set",
+    "get_job_list_for_fastq",
 
     # Update helpers
     "update_status",

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/create_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/create_helpers.py
@@ -12,7 +12,7 @@ from .models import Job, JobType
 
 
 def create_job(
-        fastq_set_id_list: List[str],
+        fastq_id_list: List[str],
         output_uri_prefix: str = None,
         job_type: Optional[JobType] = None,
 ) -> Job:
@@ -25,7 +25,7 @@ def create_job(
     return fastq_decompression_post_request(
         JOB_ENDPOINT,
         params={
-            "fastqSetIdList": fastq_set_id_list,
+            "fastqIdList": fastq_id_list,
             "jobType": job_type,
             "outputUriPrefix": output_uri_prefix,
         }

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/query_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/query_helpers.py
@@ -49,17 +49,3 @@ def get_job_list_for_fastq(
         fastqId=fastq_id,
         status=job_status
     )
-
-
-def get_job_list_for_fastq_set(
-        fastq_set_id: str,
-        job_status: JobStatus
-) -> List[Job]:
-    """
-    Check if fastq in job list
-    :return:
-    """
-    return get_decompression_job_list(
-        fastqSetId=fastq_set_id,
-        status=job_status
-    )

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/update_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_decompression/update_helpers.py
@@ -16,6 +16,7 @@ from .models import Job, JobStatus
 def update_status(
         job_id: str,
         job_status: JobStatus,
+        steps_execution_arn: Optional[str] = None,
         error_message: Optional[str] = None
 ) -> Job:
     """
@@ -31,7 +32,8 @@ def update_status(
             lambda x: x[1] is not None,
             {
                 "status": job_status,
-                "error_message": error_message
+                "errorMessage": error_message,
+                "stepsExecutionArn": steps_execution_arn
             }.items()
         ))
     )


### PR DESCRIPTION
Fastq decompression service does not use fastq set ids, but just general fastq ids