### PR TITLE
fix: unique id for alarm

### DIFF
--- a/packages/docs/@orcabus/namespaces/monitoredQueue/classes/MonitoredQueue.md
+++ b/packages/docs/@orcabus/namespaces/monitoredQueue/classes/MonitoredQueue.md
@@ -91,7 +91,7 @@ Defined in: [packages/monitored-queue/index.ts:59](https://github.com/OrcaBus/pl
 
 > **get** **queueArn**(): `string`
 
-Defined in: [packages/monitored-queue/index.ts:117](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L117)
+Defined in: [packages/monitored-queue/index.ts:120](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L120)
 
 Get the SQS queue ARN.
 

--- a/packages/monitored-queue/index.ts
+++ b/packages/monitored-queue/index.ts
@@ -1,7 +1,7 @@
 import { Construct } from "constructs";
 import {IQueue, Queue} from "aws-cdk-lib/aws-sqs";
 import { Alarm, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
-import { Duration, RemovalPolicy } from "aws-cdk-lib";
+import {Duration, Names, RemovalPolicy} from "aws-cdk-lib";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { SnsAction } from "aws-cdk-lib/aws-cloudwatch-actions";
 
@@ -100,7 +100,10 @@ export class MonitoredQueue extends Construct {
   alarmOldestMessage(queue: IQueue, queueProps?: QueueProps) {
     const seconds = queueProps?.alarmOldestMessageSeconds;
     if (seconds !== undefined) {
-      new Alarm(this, `AlarmOldestMessage-${queue.queueName}`, {
+      const uniqueId = Names.uniqueResourceName(this, {
+        maxLength: 6,
+      });
+      new Alarm(this, `AlarmOldestMessage-${queueProps?.queueName}-${uniqueId}`, {
         metric: queue.metricApproximateAgeOfOldestMessage(),
         comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
         threshold: seconds,


### PR DESCRIPTION
Related to #78 #79 

### Changes
* Unresolved tokens can't be used in the id. This fixes that by generating a unique id for the alarm inside the `MonitoriedQueue`.