### PR TITLE
fix: add missing SNS notification for alarms

### DIFF
--- a/packages/docs/@orcabus/namespaces/monitoredQueue/classes/MonitoredQueue.md
+++ b/packages/docs/@orcabus/namespaces/monitoredQueue/classes/MonitoredQueue.md
@@ -91,7 +91,7 @@ Defined in: [packages/monitored-queue/index.ts:59](https://github.com/OrcaBus/pl
 
 > **get** **queueArn**(): `string`
 
-Defined in: [packages/monitored-queue/index.ts:120](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L120)
+Defined in: [packages/monitored-queue/index.ts:125](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L125)
 
 Get the SQS queue ARN.
 
@@ -100,30 +100,6 @@ Get the SQS queue ARN.
 `string`
 
 ## Methods
-
-### alarmOldestMessage()
-
-> **alarmOldestMessage**(`queue`, `queueProps?`): `void`
-
-Defined in: [packages/monitored-queue/index.ts:100](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/monitored-queue/index.ts#L100)
-
-Create an alarm based on the oldest message in the queue.
-
-#### Parameters
-
-##### queue
-
-`IQueue`
-
-##### queueProps?
-
-[`QueueProps`](../interfaces/QueueProps.md)
-
-#### Returns
-
-`void`
-
-***
 
 ### toString()
 

--- a/packages/monitored-queue/README.md
+++ b/packages/monitored-queue/README.md
@@ -12,7 +12,7 @@ new MonitoredQueue(this, "MonitoredQueue", {
     removalPolicy: RemovalPolicy.RETAIN,
   },
   dlqProps: {
-    queueName: `$queue-dlq`,
+    queueName: "queue-dlq",
     removalPolicy: RemovalPolicy.RETAIN,
     retentionPeriod: Duration.days(14),
   },


### PR DESCRIPTION
Related to #78 #79 

### Changes
* Adds missing SNS topic notifications when the oldest message alarm is triggered