### PR TITLE
Orcabus api tools fixes

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/__init__.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/__init__.py
@@ -1,0 +1,70 @@
+# FIMXE Implement the following imports
+from typing import Optional, Dict
+
+from .globals import DATA_SHARING_SUBDOMAIN_NAME
+from ..utils.requests_helpers import get_url, get_request, get_request_response_results, patch_request
+
+
+# Get url for the subdomain
+def get_data_sharing_url(endpoint: str) -> str:
+    """
+    Get the URL for the data sharing endpoint
+    :param endpoint:
+    :return:
+    """
+    return get_url(
+        endpoint=endpoint,
+        subdomain=DATA_SHARING_SUBDOMAIN_NAME,
+    )
+
+
+# Wrappers
+def get_data_sharing_request(
+        endpoint: str,
+        params: Optional[Dict] = None,
+):
+    return get_request(
+        url=get_data_sharing_url(endpoint),
+        params=params
+    )
+
+
+def get_data_sharing_request_response_results(
+        endpoint: str,
+        params: Optional[Dict] = None,
+):
+    return get_request_response_results(
+        url=get_data_sharing_url(endpoint),
+        params=params
+    )
+
+
+def data_sharing_patch_request(
+    endpoint: str,
+    params: Optional[Dict] = None,
+):
+    return patch_request(
+        url=get_data_sharing_url(endpoint),
+        params=params
+    )
+
+
+def data_sharing_post_request(
+    endpoint: str,
+    params: Optional[Dict] = None,
+):
+    return patch_request(
+        url=get_data_sharing_url(endpoint),
+        params=params
+    )
+
+
+from .update_helpers import (
+    update_package_status,
+    update_push_job_status,
+)
+
+__all__ = [
+    "update_package_status",
+    "update_push_job_status",
+]

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/globals.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/globals.py
@@ -1,0 +1,15 @@
+# Imports
+import re
+from typing import Literal
+
+# AWS PARAMETERS
+DATA_SHARING_SUBDOMAIN_NAME = "data-sharing"
+
+# API ENDPOINTS
+PACKAGE_ENDPOINT = "api/v1/package"
+PUSH_ENDPOINT = "api/v1/push"
+
+# REGEX
+ORCABUS_ULID_REGEX_MATCH = re.compile(r'^[a-z0-9]{3}\.[A-Z0-9]{26}$')
+
+

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/models.py
@@ -1,0 +1,28 @@
+from typing import Literal, TypedDict, NotRequired
+
+PackageStatusType = Literal[
+    "PENDING",
+    "RUNNING",
+    "FAILED",
+    "ABORTED",
+    "SUCCEEDED",
+]
+
+PushJobStatusType = Literal[
+    "PENDING",
+    "RUNNING",
+    "FAILED",
+    "ABORTED",
+    "SUCCEEDED",
+]
+
+
+
+class PackageObject(TypedDict):
+    id: str
+    packageName: str
+    stepsExecutionArn: str
+    status: PackageStatusType
+    requestTime: str
+    completionTime: NotRequired[str]
+    hasExpired: NotRequired[bool]

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/update_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/update_helpers.py
@@ -1,0 +1,53 @@
+from typing import Optional
+
+from . import data_sharing_patch_request
+from .globals import PACKAGE_ENDPOINT, PUSH_ENDPOINT
+from .models import PackageStatusType, PackageObject, PushJobStatusType
+
+
+def update_package_status(
+        package_id: str,
+        package_status: PackageStatusType,
+        error_message: Optional[str] = None
+) -> PackageObject:
+    """
+    Add QC stats to a fastq_id.
+
+    :param package_id: The package id
+    :param package_status: The package status to set
+    :param error_message: Optional error message
+    """
+    return data_sharing_patch_request(
+        f"{PACKAGE_ENDPOINT}/{package_id}",
+        params=dict(filter(
+            lambda x: x[1] is not None,
+            {
+                "status": package_status,
+                "error_message": error_message
+            }.items()
+        ))
+    )
+
+
+def update_push_job_status(
+        push_job_id: str,
+        push_job_status: PushJobStatusType,
+        error_message: Optional[str] = None
+) -> PackageObject:
+    """
+    Add push job status to a push job.
+
+    :param push_job_id: The push job id
+    :param push_job_status: The push job status to set
+    :param error_message: Optional error message
+    """
+    return data_sharing_patch_request(
+        f"{PUSH_ENDPOINT}/{push_job_id}",
+        params=dict(filter(
+            lambda x: x[1] is not None,
+            {
+                "status": push_job_status,
+                "error_message": error_message
+            }.items()
+        ))
+    )

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/__init__.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/__init__.py
@@ -70,14 +70,16 @@ def fastq_post_request(
 # Create
 from .create_helpers import (
     create_fastq_set_object,
-    create_fastq_list_row_object
+    create_fastq_list_row_object,
+    create_fastq_object,
 )
 
 # Job
 from .job_helpers import (
     run_qc_stats,
     run_ntsm,
-    run_file_compression_stats
+    run_file_compression_stats,
+    run_read_count_stats
 )
 
 # Query
@@ -97,6 +99,7 @@ from .query_helpers import (
     get_fastqs_in_individual,
     get_fastqs_in_project,
     get_fastq_list_rows_in_fastq_set,
+    get_fastqs_in_fastq_set,
     get_fastq_jobs,
 )
 
@@ -111,7 +114,9 @@ from .update_helpers import (
     validate_fastq,
     invalidate_fastq,
     link_fastq_list_row_to_fastq_set,
+    link_fastq_to_fastq_set,
     unlink_fastq_list_row_from_fastq_set,
+    unlink_fastq_from_fastq_set,
     allow_additional_fastqs_to_fastq_set,
     disallow_additional_fastqs_to_fastq_set,
     set_is_current_fastq_set,
@@ -135,10 +140,12 @@ __all__ = [
     # Create
     "create_fastq_set_object",
     "create_fastq_list_row_object",
+    "create_fastq_object",
     # Job
     "run_qc_stats",
     "run_ntsm",
     "run_file_compression_stats",
+    "run_read_count_stats",
     # Query
     "get_fastq",
     "get_fastq_set",
@@ -155,6 +162,7 @@ __all__ = [
     "get_fastqs_in_individual",
     "get_fastqs_in_project",
     "get_fastq_list_rows_in_fastq_set",
+    "get_fastqs_in_fastq_set",
     "get_fastq_jobs",
     # Updaters
     "add_qc_stats",
@@ -166,7 +174,9 @@ __all__ = [
     "validate_fastq",
     "invalidate_fastq",
     "link_fastq_list_row_to_fastq_set",
+    "link_fastq_to_fastq_set",
     "unlink_fastq_list_row_from_fastq_set",
+    "unlink_fastq_from_fastq_set",
     "allow_additional_fastqs_to_fastq_set",
     "disallow_additional_fastqs_to_fastq_set",
     "set_is_current_fastq_set",

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/create_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/create_helpers.py
@@ -17,18 +17,30 @@ from typing import Unpack
 
 # Local imports
 from . import fastq_post_request
-from .globals import FASTQ_LIST_ROW_ENDPOINT, FASTQ_SET_ENDPOINT
-from .models import FastqListRow, FastqSet, FastqListRowCreate, FastqSetCreate
+from .globals import FASTQ_ENDPOINT, FASTQ_SET_ENDPOINT
+from .models import Fastq, FastqSet, FastqCreate, FastqSetCreate
 
 
-def create_fastq_list_row_object(**kwargs: Unpack[FastqListRowCreate]) -> FastqListRow:
+def create_fastq_list_row_object(**kwargs: Unpack[FastqCreate]) -> Fastq:
+    """
+    DEPRECATED: Use create_fastq_object instead.
+    """
+    return create_fastq_object(**kwargs)
+
+
+def create_fastq_object(**kwargs: Unpack[FastqCreate]) -> Fastq:
     """
     Add a fastq list row object to the database.
     Returns the created fastq list row object
     """
-    return FastqListRow(
+    # Raise error if any of the kwargs are not in the FastqCreate
+    for key in kwargs.keys():
+        if key not in FastqCreate.__annotations__:
+            raise ValueError(f"Invalid parameter: {key}")
+
+    return Fastq(
         **fastq_post_request(
-            endpoint=FASTQ_LIST_ROW_ENDPOINT,
+            endpoint=FASTQ_ENDPOINT,
             params=dict(kwargs)
         )
     )
@@ -39,6 +51,11 @@ def create_fastq_set_object(**kwargs: Unpack[FastqSetCreate]) -> FastqSet:
     Add a fastq set object to the database.
     Returns the created fastq set object
     """
+    # Raise error if any of the kwargs are not in the FastqCreate
+    for key in kwargs.keys():
+        if key not in FastqSetCreate.__annotations__:
+            raise ValueError(f"Invalid parameter: {key}")
+
     return FastqSet(
         **fastq_post_request(
             endpoint=FASTQ_SET_ENDPOINT,

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/globals.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/globals.py
@@ -6,7 +6,7 @@ import re
 FASTQ_SUBDOMAIN_NAME = "fastq"
 
 # API ENDPOINTS
-FASTQ_LIST_ROW_ENDPOINT = "api/v1/fastq"
+FASTQ_ENDPOINT = "api/v1/fastq"
 FASTQ_SET_ENDPOINT = "api/v1/fastqSet"
 
 # REGEX

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/job_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/job_helpers.py
@@ -11,7 +11,7 @@ Update helpers for the update script.
 
 # Local imports
 from . import fastq_patch_request
-from .globals import FASTQ_LIST_ROW_ENDPOINT
+from .globals import FASTQ_ENDPOINT
 from .models import Job
 
 
@@ -23,7 +23,7 @@ def run_qc_stats(fastq_id: str) -> Job:
     """
     return Job(
         **fastq_patch_request(
-            f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}:runQcStats"
+            f"{FASTQ_ENDPOINT}/{fastq_id}:runQcStats"
         )
     )
 
@@ -36,7 +36,7 @@ def run_ntsm(fastq_id: str) -> Job:
     """
     return Job(
         **fastq_patch_request(
-            f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}:runNtsm"
+            f"{FASTQ_ENDPOINT}/{fastq_id}:runNtsm"
         )
     )
 
@@ -48,6 +48,18 @@ def run_file_compression_stats(fastq_id: str) -> Job:
     """
     return Job(
         **fastq_patch_request(
-            f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}:runFileCompressionInformation"
+            f"{FASTQ_ENDPOINT}/{fastq_id}:runFileCompressionInformation"
+        )
+    )
+
+def run_read_count_stats(fastq_id: str) -> Job:
+    """
+    Run file compression stats for a fastq_id.
+
+    :param fastq_id: Fastq str
+    """
+    return Job(
+        **fastq_patch_request(
+            f"{FASTQ_ENDPOINT}/{fastq_id}:runReadCountInformation"
         )
     )

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/models.py
@@ -40,22 +40,27 @@ from typing import (
     TypedDict,
     Optional,
     Dict,
-    List, NotRequired, Union, Literal
+    List, NotRequired, Union,
+    Literal
 )
 from datetime import datetime
 
 
-class JobType(Enum):
-    QC = 'QC'
-    FILE_COMPRESSION = 'FILE_COMPRESSION'
-    NTSM = 'NTSM'
+JobType = Literal[
+    'QC',
+    'FILE_COMPRESSION',
+    'NTSM',
+    'READ_COUNT',
+]
 
 
-class JobStatus(Enum):
-    PENDING = "PENDING"
-    RUNNING = "RUNNING"
-    FAILED = "FAILED"
-    SUCCEEDED = "SUCCEEDED"
+JobStatus = Literal[
+    "PENDING",
+    "RUNNING",
+    "FAILED",
+    "SUCCEEDED",
+]
+
 
 
 class FileStorageObject(TypedDict):
@@ -81,6 +86,7 @@ class Library(TypedDict):
     libraryId: str
 
 
+# Deprecated: Use FastqCreate instead
 class FastqListRowCreate(TypedDict):
     fastqSetId: Optional[str]
     index: str
@@ -98,6 +104,7 @@ class FastqListRowCreate(TypedDict):
     ntsm: Optional[FileStorageObject]
 
 
+# Deprecated: Use Fastq instead
 class FastqListRow(TypedDict):
     id: str
     fastqSetId: Optional[str]
@@ -116,9 +123,44 @@ class FastqListRow(TypedDict):
     ntsm: Optional[FileStorageObject]
 
 
+class Fastq(TypedDict):
+    id: str
+    fastqSetId: Optional[str]
+    index: str
+    lane: int
+    instrumentRunId: str
+    library: Library
+    platform: Optional[str]
+    center: Optional[str]
+    date: Optional[datetime]
+    readSet: Optional[ReadSet]
+    qc: Optional[Dict]
+    readCount: Optional[int]
+    baseCountEst: Optional[int]
+    isValid: Optional[bool]
+    ntsm: Optional[FileStorageObject]
+
+
+class FastqCreate(TypedDict):
+    fastqSetId: Optional[str]
+    index: str
+    lane: int
+    instrumentRunId: str
+    library: Library
+    platform: Optional[str]
+    center: Optional[str]
+    date: Optional[datetime]
+    readSet: Optional[ReadSet]
+    qc: Optional[Dict]
+    readCount: Optional[int]
+    baseCountEst: Optional[int]
+    isValid: Optional[bool]
+    ntsm: Optional[FileStorageObject]
+
+
 class FastqSetCreate(TypedDict):
     library: Library
-    fastqSet: List[Union[str, FastqListRow]]
+    fastqSet: List[Union[str, Fastq]]
     allowAdditionalFastq: bool
     isCurrentFastqSet: bool
 
@@ -126,7 +168,7 @@ class FastqSetCreate(TypedDict):
 class FastqSet(TypedDict):
     id: str
     library: Library
-    fastqSet: List[FastqListRow]
+    fastqSet: List[Fastq]
     allowAdditionalFastq: bool
     isCurrentFastqSet: bool
 
@@ -176,15 +218,21 @@ class Job(TypedDict):
     startTime: datetime
     endTime: Optional[datetime]
 
-
+# Deprecated: Use BoolLiteral instead
 class BoolAllEnum(Enum):
     ALL = "ALL"
     true = True
     false = False
 
+BoolLiteral = Literal[
+    'ALL',
+    True,
+    False
+]
+
 
 class FastqGetResponseParameters(TypedDict):
-    includeS3Details: NotRequired[BoolAllEnum]
+    includeS3Details: NotRequired[BoolLiteral]
 
 
 class StandardQueryParameters(TypedDict):
@@ -224,15 +272,28 @@ InstrumentRunIdQueryParametersList = TypedDict(
 )
 
 
-class FastqListRowQueryParameters(
+# Deprecated: Use FastqQueryParameters instead
+class FastqParameters(
     StandardQueryParameters,
     MetadataQueryParameter,
     InstrumentRunIdQueryParameters,
     MetadataQueryParametersList,
     InstrumentRunIdQueryParametersList
 ):
-    valid: NotRequired[BoolAllEnum]
-    includeS3Details: NotRequired[BoolAllEnum]
+    valid: NotRequired[BoolLiteral]
+    includeS3Details: NotRequired[BoolLiteral]
+    fastqSetId: NotRequired[str]
+
+
+class FastqQueryParameters(
+    StandardQueryParameters,
+    MetadataQueryParameter,
+    InstrumentRunIdQueryParameters,
+    MetadataQueryParametersList,
+    InstrumentRunIdQueryParametersList
+):
+    valid: NotRequired[BoolLiteral]
+    includeS3Details: NotRequired[BoolLiteral]
     fastqSetId: NotRequired[str]
 
 
@@ -242,9 +303,9 @@ class FastqSetQueryParameters(
     MetadataQueryParametersList,
     InstrumentRunIdQueryParameters
 ):
-    currentFastqSet: NotRequired[BoolAllEnum]
-    allowAdditionalFastq: NotRequired[BoolAllEnum]
-    includeS3Details: NotRequired[BoolAllEnum]
+    currentFastqSet: NotRequired[BoolLiteral]
+    allowAdditionalFastq: NotRequired[BoolLiteral]
+    includeS3Details: NotRequired[BoolLiteral]
 
 # Additional types
 VALID_BATCH_KEYS = Literal[

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/query_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/query_helpers.py
@@ -25,20 +25,22 @@ from typing import List, Unpack
 from fastapi.encoders import jsonable_encoder
 
 from . import get_fastq_request_response_results, get_fastq_request
-from .globals import FASTQ_LIST_ROW_ENDPOINT, FASTQ_SET_ENDPOINT
-from .models import FastqListRow, FastqSet, Job, FastqListRowQueryParameters, FastqSetQueryParameters, \
-    FastqGetResponseParameters, VALID_BATCH_KEYS
+from .globals import FASTQ_ENDPOINT, FASTQ_SET_ENDPOINT
+from .models import (
+    FastqSet, Job, FastqParameters, FastqSetQueryParameters,
+    FastqGetResponseParameters, VALID_BATCH_KEYS, Fastq
+)
 
 
-def get_fastq(fastq_id: str, **kwargs: Unpack[FastqGetResponseParameters]) -> FastqListRow:
+def get_fastq(fastq_id: str, **kwargs: Unpack[FastqGetResponseParameters]) -> Fastq:
     # Raise error if any of the kwargs are not in the FastqSetQueryParameters
     for key in kwargs.keys():
         if key not in FastqGetResponseParameters.__annotations__:
             raise ValueError(f"Invalid parameter: {key}")
 
-    return FastqListRow(
+    return Fastq(
         **get_fastq_request(
-            f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}",
+            f"{FASTQ_ENDPOINT}/{fastq_id}",
             params=dict(kwargs)
         )
     )
@@ -67,17 +69,17 @@ def get_fastq_set(
     )
 
 
-def get_fastqs(**kwargs: Unpack[FastqListRowQueryParameters]) -> List[FastqListRow]:
+def get_fastqs(**kwargs: Unpack[FastqParameters]) -> List[Fastq]:
     """
     Get all fastqs
     """
-    # Raise error if any of the kwargs are not in the FastqListRowQueryParameters
+    # Raise error if any of the kwargs are not in the FastqParameters
     for key in kwargs.keys():
-        if key not in FastqListRowQueryParameters.__annotations__:
+        if key not in FastqParameters.__annotations__:
             raise ValueError(f"Invalid parameter: {key}")
 
     return get_fastq_request_response_results(
-        FASTQ_LIST_ROW_ENDPOINT,
+        FASTQ_ENDPOINT,
         params=dict(kwargs)
     )
 
@@ -89,7 +91,7 @@ def get_fastq_sets(**kwargs: Unpack[FastqSetQueryParameters]) -> List[FastqSet]:
     :param kwargs:
     :return:
     """
-    # Raise error if any of the kwargs are not in the FastqListRowQueryParameters
+    # Raise error if any of the kwargs are not in the FastqParameters
     for key in kwargs.keys():
         if key not in FastqSetQueryParameters.__annotations__:
             raise ValueError(f"Invalid parameter: {key}")
@@ -123,7 +125,7 @@ def get_fastqs_batched(
         item_list: List[str],
         batch_size: int = 100,
         **kwargs
-) -> List[FastqListRow]:
+) -> List[Fastq]:
     """
     Get all fastqs in a list of libraries
     """
@@ -153,7 +155,7 @@ def get_fastqs_batched(
 
 def get_fastqs_in_library_list(
         library_id_list: List[str]
-) -> List[FastqListRow]:
+) -> List[Fastq]:
     """
     Get all fastqs in a list of libraries
     """
@@ -230,7 +232,16 @@ def get_fastqs_in_project(project_id):
 
 def get_fastq_list_rows_in_fastq_set(fastq_set_id):
     """
+    DEPRECATED: Use get_fastqs_in_fastq_set instead
+    """
+    return get_fastqs_in_fastq_set(fastq_set_id)
+
+
+def get_fastqs_in_fastq_set(fastq_set_id: str) -> List[Fastq]:
+    """
     Get all fastqs in a fastq set
+    :param fastq_set_id:
+    :return:
     """
     return get_fastqs(
         fastqSetId=fastq_set_id
@@ -244,6 +255,6 @@ def get_fastq_jobs(fastq_id: str) -> List[Job]:
     return list(map(
         lambda job_iter_: Job(**job_iter_),
         get_fastq_request_response_results(
-            f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/jobs"
+            f"{FASTQ_ENDPOINT}/{fastq_id}/jobs"
         )
     ))

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/update_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/update_helpers.py
@@ -15,15 +15,15 @@ Update helpers for the update script.
 
 # Local imports
 from . import fastq_patch_request
-from .globals import FASTQ_LIST_ROW_ENDPOINT, FASTQ_SET_ENDPOINT
+from .globals import FASTQ_ENDPOINT, FASTQ_SET_ENDPOINT
 from .models import (
-    QcStats, FastqListRow, ReadCount,
+    QcStats, Fastq, ReadCount,
     FileCompressionInformation, FileStorageObject, ReadSet,
     FastqSet
 )
 
 
-def add_qc_stats(fastq_id: str, qc_stats: QcStats) -> FastqListRow:
+def add_qc_stats(fastq_id: str, qc_stats: QcStats) -> Fastq:
     """
     Add QC stats to a fastq_id.
 
@@ -36,12 +36,12 @@ def add_qc_stats(fastq_id: str, qc_stats: QcStats) -> FastqListRow:
             raise ValueError(f"Invalid parameter: {key}")
 
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/addQcStats",
+        f"{FASTQ_ENDPOINT}/{fastq_id}/addQcStats",
         params=dict(qc_stats)
     )
 
 
-def add_read_count(fastq_id: str, read_count: ReadCount) -> FastqListRow:
+def add_read_count(fastq_id: str, read_count: ReadCount) -> Fastq:
     """
     Add read count to a fastq id
     :param fastq_id:
@@ -53,12 +53,12 @@ def add_read_count(fastq_id: str, read_count: ReadCount) -> FastqListRow:
             raise ValueError(f"Invalid parameter: {key}")
 
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/addReadCount",
+        f"{FASTQ_ENDPOINT}/{fastq_id}/addReadCount",
         params=dict(read_count)
     )
 
 
-def add_file_compression_information(fastq_id: str, file_compression_information: FileCompressionInformation) -> FastqListRow:
+def add_file_compression_information(fastq_id: str, file_compression_information: FileCompressionInformation) -> Fastq:
     """
     Add file compression information to a fastq id
     :param fastq_id:
@@ -70,12 +70,12 @@ def add_file_compression_information(fastq_id: str, file_compression_information
             raise ValueError(f"Invalid parameter: {key}")
 
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/addFileCompressionInformation",
+        f"{FASTQ_ENDPOINT}/{fastq_id}/addFileCompressionInformation",
         params=dict(file_compression_information)
     )
 
 
-def add_ntsm_storage_object(fastq_id: str, ntsm_fastq_storage_object: FileStorageObject) -> FastqListRow:
+def add_ntsm_storage_object(fastq_id: str, ntsm_fastq_storage_object: FileStorageObject) -> Fastq:
     """
     Add a Ntsm storage object to a fastq id.
 
@@ -87,12 +87,12 @@ def add_ntsm_storage_object(fastq_id: str, ntsm_fastq_storage_object: FileStorag
             raise ValueError(f"Invalid parameter: {key}")
 
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/addNtsmStorageObject",
+        f"{FASTQ_ENDPOINT}/{fastq_id}/addNtsmStorageObject",
         params=dict(ntsm_fastq_storage_object)
     )
 
 
-def add_read_set(fastq_id: str, read_set: ReadSet) -> FastqListRow:
+def add_read_set(fastq_id: str, read_set: ReadSet) -> Fastq:
     """
     Add a read set to a fastq id.
 
@@ -104,48 +104,62 @@ def add_read_set(fastq_id: str, read_set: ReadSet) -> FastqListRow:
             raise ValueError(f"Invalid parameter: {key}")
 
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/addFastqPairStorageObject",
+        f"{FASTQ_ENDPOINT}/{fastq_id}/addFastqPairStorageObject",
         params=dict(read_set)
     )
 
 
-def detach_read_set(fastq_id: str) -> FastqListRow:
+def detach_read_set(fastq_id: str) -> Fastq:
     """
     Detach a read set to a fastq id.
 
     :param fastq_id: Fastq str
     """
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/detachFastqPairStorageObject"
+        f"{FASTQ_ENDPOINT}/{fastq_id}/detachFastqPairStorageObject"
     )
 
 
-def validate_fastq(fastq_id: str) -> FastqListRow:
+def validate_fastq(fastq_id: str) -> Fastq:
     """
     Validate a fastq id.
 
     :param fastq_id: Fastq str
     """
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/validate"
+        f"{FASTQ_ENDPOINT}/{fastq_id}/validate"
     )
 
 
-def invalidate_fastq(fastq_id: str) -> FastqListRow:
+def invalidate_fastq(fastq_id: str) -> Fastq:
     """
     Invalidate a fastq id.
 
     :param fastq_id: Fastq str
     """
     return fastq_patch_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/invalidate"
+        f"{FASTQ_ENDPOINT}/{fastq_id}/invalidate"
     )
 
 
 def link_fastq_list_row_to_fastq_set(fastq_id: str, fastq_set_id: str) -> FastqSet:
     """
+    Deprecated: Use `link_fastq_to_fast_set` instead.
     Link a fastq id to a fastq set.
 
+    :param fastq_id:
+    :param fastq_set_id:
+    :return:
+    """
+    return link_fastq_to_fastq_set(
+        fastq_id=fastq_id,
+        fastq_set_id=fastq_set_id
+    )
+
+
+def link_fastq_to_fastq_set(fastq_id: str, fastq_set_id: str) -> FastqSet:
+    """
+    Link a fastq id to a fastq set.
     :param fastq_id:
     :param fastq_set_id:
     :return:
@@ -156,6 +170,16 @@ def link_fastq_list_row_to_fastq_set(fastq_id: str, fastq_set_id: str) -> FastqS
 
 
 def unlink_fastq_list_row_from_fastq_set(fastq_id: str, fastq_set_id: str) -> FastqSet:
+    """
+    Deprecated: Use `unlink_fastq_from_fastq_set` instead.
+    """
+    return unlink_fastq_from_fastq_set(
+        fastq_id=fastq_id,
+        fastq_set_id=fastq_set_id
+    )
+
+
+def unlink_fastq_from_fastq_set(fastq_id: str, fastq_set_id: str) -> FastqSet:
     """
     Unlink a fastq id from a fastq set.
 

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/workflow_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/workflow_helpers.py
@@ -8,15 +8,16 @@ Workflow helpers - a collection of helper functions for the workflow
 
 # Standard library imports
 from typing import List
+
 # Local imports
 from . import get_fastq_request
-from .globals import FASTQ_LIST_ROW_ENDPOINT, FASTQ_SET_ENDPOINT
+from .globals import FASTQ_ENDPOINT, FASTQ_SET_ENDPOINT
 from .models import FastqListRowDict
 
 
 def to_fastq_list_row(fastq_id) -> FastqListRowDict:
     return get_fastq_request(
-        f"{FASTQ_LIST_ROW_ENDPOINT}/{fastq_id}/toFastqListRow"
+        f"{FASTQ_ENDPOINT}/{fastq_id}/toFastqListRow"
     )
 
 def to_fastq_list_rows(fastq_set_id: str) -> List[FastqListRowDict]:

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/__init__.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/__init__.py
@@ -6,7 +6,10 @@ from typing import Dict, Optional
 # Local imports
 from .globals import FASTQ_UNARCHIVING_SUBDOMAIN_NAME
 from ..utils.requests_helpers import (
-    get_request_response_results, get_url, patch_request, get_request
+    get_request_response_results,
+    get_url,
+    patch_request,
+    get_request
 )
 
 

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/create_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/create_helpers.py
@@ -16,12 +16,12 @@ def create_job(fastq_ids: List[str], job_type: Optional[JobType] = None) -> Job:
     Create the job
     """
     if job_type is None:
-        job_type = JobType.S3_UNARCHIVING
+        job_type = 'S3_UNARCHIVING'
 
     return fastq_unarchiving_post_request(
         JOB_ENDPOINT,
         params={
             "fastqIds": fastq_ids,
-            "jobType": job_type.value
+            "jobType": job_type
         }
     )

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/globals.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/globals.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import re
-from enum import Enum
 
 # AWS PARAMETERS
 FASTQ_UNARCHIVING_SUBDOMAIN_NAME = "fastq-unarchiving"
@@ -12,10 +11,3 @@ JOB_ENDPOINT = "api/v1/jobs"
 # REGEX
 ORCABUS_ULID_REGEX_MATCH = re.compile(r'^[a-z0-9]{3}\.[A-Z0-9]{26}$')
 
-
-class JobStatus(Enum):
-    PENDING = "PENDING"
-    RUNNING = "RUNNING"
-    FAILED = "FAILED"
-    ABORTED = "ABORTED"
-    SUCCEEDED = "SUCCEEDED"

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/models.py
@@ -13,28 +13,27 @@
 
 from typing import (
     TypedDict, NotRequired,
+    Literal
 )
 
-from enum import Enum
+JobType = Literal[
+    "S3_UNARCHIVING",
+]
 
 
-class JobType(Enum):
-    S3_UNARCHIVING = "S3_UNARCHIVING"
-
-
-class JobStatus(Enum):
-    PENDING = "PENDING"
-    RUNNING = "RUNNING"
-    FAILED = "FAILED"
-    ABORTED = "ABORTED"
-    SUCCEEDED = "SUCCEEDED"
-
+JobStatusType = Literal[
+    "PENDING",
+    "RUNNING",
+    "FAILED",
+    "ABORTED",
+    "SUCCEEDED",
+]
 
 class Job(TypedDict):
     id: str
     jobType: JobType
     stepsExecutionArn: str
-    status: JobStatus
+    status: JobStatusType
     startTime: str
     endTime: str
     errorMessages: str
@@ -42,7 +41,7 @@ class Job(TypedDict):
 
 class JobQueryParameters(TypedDict):
     fastqId: NotRequired[str]
-    status: NotRequired[JobStatus]
+    status: NotRequired[JobStatusType]
     createdAfter: NotRequired[str]
     createdBefore: NotRequired[str]
     completedAfter: NotRequired[str]

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/query_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/query_helpers.py
@@ -14,7 +14,7 @@ from typing import List, Unpack
 
 # Local imports
 from . import get_fastq_unarchiving_request_response_results
-from .models import Job, JobStatus, JobQueryParameters
+from .models import Job, JobStatusType, JobQueryParameters
 
 from .globals import JOB_ENDPOINT
 
@@ -40,7 +40,7 @@ def get_unarchiving_job_list(**kwargs: Unpack[JobQueryParameters]) -> List[Job]:
 
 def get_job_list_for_fastq(
         fastq_id: str,
-        job_status: JobStatus
+        job_status: JobStatusType
 ) -> List[Job]:
     """
     Check if fastq in job list
@@ -48,5 +48,5 @@ def get_job_list_for_fastq(
     """
     return get_unarchiving_job_list(
         fastqId=fastq_id,
-        status=job_status.value
+        status=job_status
     )

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/update_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq_unarchiving/update_helpers.py
@@ -17,13 +17,13 @@ from typing import Optional
 
 # Local imports
 from . import fastq_unarchiving_patch_request
-from .globals import JobStatus, JOB_ENDPOINT
-from .models import Job
+from .globals import JOB_ENDPOINT
+from .models import Job, JobStatusType
 
 
 def update_status(
         job_id: str,
-        job_status: JobStatus,
+        job_status: JobStatusType,
         error_message: Optional[str] = None
 ) -> Job:
     """

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/__init__.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/__init__.py
@@ -40,10 +40,12 @@ def get_file_manager_request(
 
 def file_manager_patch_request(
         endpoint: str,
+        json_data: Optional[Dict] = None,
         params: Optional[Dict] = None
 ):
     return patch_request(
         get_file_manager_url(endpoint),
+        json_data=json_data,
         params=params
     )
 

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/globals.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/globals.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from enum import Enum
 
 # AWS PARAMETERS
 FILEMANAGER_SUBDOMAIN_NAME = "file"
@@ -41,30 +40,3 @@ S3_PREFIXES_BY_ACCOUNT_ID = {
     },
 }
 
-# FROM FileManager Schema
-# "DeepArchive"
-# "Glacier"
-# "GlacierIr"
-# "IntelligentTiering"
-# "OnezoneIa"
-# "Outposts"
-# "ReducedRedundancy"
-# "Snow"
-# "Standard"
-# "StandardIa"
-class StorageEnum(Enum):
-    STANDARD = "Standard"
-    STANDARD_IA = "StandardIa"
-    INTELLIGENT_TIERING = "IntelligentTiering"
-    GLACIER_INSTANT_RETRIEVAL = "GlacierIr"
-    GLACIER = "Glacier"
-    DEEP_ARCHIVE = "DeepArchive"
-
-
-class StoragePriority(Enum):
-    STANDARD = 1
-    STANDARD_IA = 2
-    INTELLIGENT_TIERING = 3
-    GLACIER_INSTANT_RETRIEVAL = 4
-    GLACIER = 5
-    DEEP_ARCHIVE = 6

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, TypedDict, Dict
+from typing import Optional, TypedDict, Dict, Literal
 
 """
 Example File Object response
@@ -26,6 +26,23 @@ Example File Object response
     }
 """
 
+StorageClassType = Literal[
+    "Standard",
+    "StandardIa",
+    "IntelligentTiering",
+    "GlacierIr",
+    "Glacier",
+    "DeepArchive",
+]
+
+StorageClassPriority: Dict[StorageClassType, int] = {
+    "Standard": 1,
+    "StandardIa": 2,
+    "IntelligentTiering": 3,
+    "GlacierIr": 4,
+    "Glacier": 5,
+    "DeepArchive": 6,
+}
 
 class FileObject(TypedDict):
     # Identifier
@@ -47,7 +64,7 @@ class FileObject(TypedDict):
     numberReordered: int
     sequencer: str
     size: int
-    storageClass: str
+    storageClass: StorageClassType
 
     # Attribute attributes
     attributes: Optional[Dict]

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/utils/requests_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/utils/requests_helpers.py
@@ -9,6 +9,8 @@ from copy import deepcopy
 
 from requests import HTTPError
 
+from fastapi.encoders import jsonable_encoder
+
 # Locals
 from .aws_helpers import (
     get_orcabus_token, get_hostname
@@ -103,7 +105,11 @@ def get_request(url: str, params: Optional[Dict] = None) -> Dict:
     return response.json()
 
 
-def patch_request(url: str, params: Optional[Dict] = None) -> Dict:
+def patch_request(
+        url: str,
+        json_data: Optional[Dict] = None,
+        params: Optional[Dict] = None
+) -> Dict:
     # Get authorization header
     headers = {
         "Authorization": f"Bearer {get_orcabus_token()}"
@@ -119,7 +125,8 @@ def patch_request(url: str, params: Optional[Dict] = None) -> Dict:
     response = requests.patch(
         url,
         headers=headers,
-        json=req_params
+        params=req_params,
+        json=json_data
     )
 
     try:


### PR DESCRIPTION
* Update patch request to accept json data alongside params
* Add in storage classes as literals rather than enums (filemanager),
* Move fastq unarchiving to use literals over global enums (fastq unarchiving)
* Rename fastq list row to fastq  (fastq)
* Added data sharing functions toolkit to orcabus api tools (data sharing)