### PR TITLE
Simplify the filemanager logic to get files when given a portal run id

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/data_sharing/models.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict, NotRequired
+from typing import Literal, TypedDict, NotRequired, Union
 
 PackageStatusType = Literal[
     "PENDING",
@@ -28,5 +28,5 @@ class PackageObject(TypedDict):
 
 
 class JobPatchParameters(TypedDict):
-    status: str
+    status: Union[PackageStatusType, PushJobStatusType]
     errorMessage: NotRequired[str]


### PR DESCRIPTION
Now that archiving buckets are up to date, we can pull ingest ids using only the portal run id