### PR TITLE
Correctly parse booleans in params

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/query_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/query_helpers.py
@@ -18,12 +18,15 @@ get_fastqs_in_project
 get_fastq_by_rgid
 
 """
+
+# Standard imports
 from functools import reduce
 from itertools import batched
 from operator import concat
 from typing import List, Unpack
 from fastapi.encoders import jsonable_encoder
 
+# Local imports
 from . import get_fastq_request_response_results, get_fastq_request
 from .globals import FASTQ_ENDPOINT, FASTQ_SET_ENDPOINT, RGID_ENDPOINT
 from .models import (

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/utils/requests_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/utils/requests_helpers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import json
 from typing import Dict, Optional, List, Union
 from urllib.parse import urlunparse, unquote
 
@@ -7,6 +8,7 @@ import requests
 import logging
 from copy import deepcopy
 
+from fastapi.encoders import jsonable_encoder
 from requests import HTTPError
 
 # Locals
@@ -62,12 +64,24 @@ def get_request_response_results(url: str, params: Optional[Dict] = None) -> Lis
         params if params is not None else {}
     )
 
+    # Iterate through each of the params, if any of the values
+    # are boolean, convert them to strings via json.dumps
+    req_params = dict(map(
+        lambda kv_iter_: (
+            kv_iter_[0], (
+                json.dumps(kv_iter_[1])
+                if isinstance(kv_iter_[1], bool)
+                else kv_iter_[1]
+            )
+        ),
+        req_params.items()
+    ))
 
     # Make the request
     response = requests.get(
         url,
         headers=headers,
-        params=req_params
+        params=jsonable_encoder(req_params)
     )
 
     response.raise_for_status()


### PR DESCRIPTION
Booleans are parsed as str(bool), so `True` becomes `True` and `False` becomes `False`, instead `True` should be come `true` and `False` should become `false`