### PR TITLE
Cache URI should be forwarded on for nextflow support

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/icav2_wes/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/icav2_wes/models.py
@@ -23,6 +23,7 @@ class EngineParameters(TypedDict):
     # Locations
     outputUri: str
     logsUri: str
+    cacheUri: NotRequired[str]
 
 
 class WESPostRequest(TypedDict):


### PR DESCRIPTION
Add nf-core support for wes models.

Nextflow pipelines need the cache uri in order for us to have a spot to put the samplesheet.