### PR TITLE
Forward get_workflow_from_portal_run_id through same workflow logic

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/workflow/workflow_run_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/workflow/workflow_run_helpers.py
@@ -60,8 +60,8 @@ def get_workflow_run_from_portal_run_id(portal_run_id: str) -> WorkflowRun:
         raise WorkflowRunNotFoundError(portal_run_id=portal_run_id)
 
     try:
-        return get_workflow_request(
-            f"{WORKFLOW_RUN_ENDPOINT}/{workflow_runs_list[0]['orcabusId']}",
+        return get_workflow_run(
+            workflow_runs_list[0]['orcabusId'],
         )
     except HTTPError as e:
         raise WorkflowRunNotFoundError(portal_run_id=portal_run_id) from e


### PR DESCRIPTION
Coerce function get_workflow_from_portal_run_id to convert the workflow object to use name and version instead of workflowName and workflowVersion