### PR TITLE
There may be multiple copies of a fastq file

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/file_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/filemanager/file_helpers.py
@@ -100,7 +100,12 @@ def get_file_object_from_ingest_id(ingest_id: str, **kwargs) -> FileObject:
     ))
 
     # Order by storage class
-    file_objects_list.sort(key=lambda file_obj_iter_: StorageClassPriority[file_obj_iter_['storageClass']])
+    file_objects_list.sort(
+        key=lambda file_obj_iter_: (
+            StorageClassPriority[file_obj_iter_['storageClass']],
+            -file_obj_iter_['eventTime']
+        )
+    )
 
     # Return as a FileObject model
     return file_objects_list[0]


### PR DESCRIPTION
This isn't a perfect solution but is a stop gap for now. 

Prioritise the latest event timestamp to return the latest file object for a given ingest id