### PR TITLE
feat: add the tothill project data bucket to the filemanager

### DIFF
--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_ACCESS_KEY_ARNS.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_ACCESS_KEY_ARNS.md
@@ -8,4 +8,4 @@
 
 > `const` **FILE\_MANAGER\_ACCESS\_KEY\_ARNS**: `Record`\<[`StageName`](../../account/type-aliases/StageName.md), `string`\>
 
-Defined in: [packages/shared-config/file-manager.ts:59](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L59)
+Defined in: [packages/shared-config/file-manager.ts:60](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L60)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_CACHE_BUCKETS.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_CACHE_BUCKETS.md
@@ -8,4 +8,4 @@
 
 > `const` **FILE\_MANAGER\_CACHE\_BUCKETS**: `Record`\<[`StageName`](../../account/type-aliases/StageName.md), `string`[]\>
 
-Defined in: [packages/shared-config/file-manager.ts:43](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L43)
+Defined in: [packages/shared-config/file-manager.ts:44](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L44)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_CROSS_ACCOUNT_BUCKETS.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_CROSS_ACCOUNT_BUCKETS.md
@@ -8,4 +8,4 @@
 
 > `const` **FILE\_MANAGER\_CROSS\_ACCOUNT\_BUCKETS**: `string`[]
 
-Defined in: [packages/shared-config/file-manager.ts:51](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L51)
+Defined in: [packages/shared-config/file-manager.ts:52](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L52)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_DOMAIN_PREFIX.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_DOMAIN_PREFIX.md
@@ -8,4 +8,4 @@
 
 > `const` **FILE\_MANAGER\_DOMAIN\_PREFIX**: `"file"` = `"file"`
 
-Defined in: [packages/shared-config/file-manager.ts:67](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L67)
+Defined in: [packages/shared-config/file-manager.ts:68](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L68)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_INGEST_ROLE.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_INGEST_ROLE.md
@@ -8,4 +8,4 @@
 
 > `const` **FILE\_MANAGER\_INGEST\_ROLE**: `"orcabus-file-manager-ingest-role"` = `"orcabus-file-manager-ingest-role"`
 
-Defined in: [packages/shared-config/file-manager.ts:65](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L65)
+Defined in: [packages/shared-config/file-manager.ts:66](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L66)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_PRESIGN_USER.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_PRESIGN_USER.md
@@ -8,4 +8,4 @@
 
 > `const` **FILE\_MANAGER\_PRESIGN\_USER**: `"orcabus-file-manager-presign-user"` = `"orcabus-file-manager-presign-user"`
 
-Defined in: [packages/shared-config/file-manager.ts:66](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L66)
+Defined in: [packages/shared-config/file-manager.ts:67](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L67)

--- a/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_PRESIGN_USER_SECRET.md
+++ b/packages/docs/@orcabus/namespaces/sharedConfig/namespaces/fileManager/variables/FILE_MANAGER_PRESIGN_USER_SECRET.md
@@ -8,4 +8,4 @@
 
 > `const` **FILE\_MANAGER\_PRESIGN\_USER\_SECRET**: `"orcabus/file-manager-presign-user"` = `"orcabus/file-manager-presign-user"`
 
-Defined in: [packages/shared-config/file-manager.ts:55](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L55)
+Defined in: [packages/shared-config/file-manager.ts:56](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/shared-config/file-manager.ts#L56)

--- a/packages/shared-config/file-manager.ts
+++ b/packages/shared-config/file-manager.ts
@@ -36,6 +36,7 @@ export const FILE_MANAGER_BUCKETS: Record<StageName, string[]> = {
     `pipeline-montauk-977251586657-${PROD_ENVIRONMENT.region}`,
     "research-data-550435500918-ap-southeast-2",
     "project-data-889522050439-ap-southeast-2",
+    "project-data-491085415398-ap-southeast-2",
   ],
 };
 


### PR DESCRIPTION
Related to https://github.com/OrcaBus/service-filemanager/issues/60.

### Changes
* Adds `project-data-491085415398-ap-southeast-2` to the filemanager.