### PR TITLE
Chore: Migrate npm token to OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [released]
 
+permissions:
+  id-token: write  # Required for NPM OIDC
+  contents: read
+
 jobs:
   publish-to-npm-registry:
     runs-on: ubuntu-latest
@@ -34,5 +38,5 @@ jobs:
       - run: pnpm publib-npm
         working-directory: ./packages
         env:
-          NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-          NPM_ACCESS_LEVEL: public
+          NPM_TRUSTED_PUBLISHER: "true"
+          NPM_ACCESS_LEVEL: "public"


### PR DESCRIPTION
closes #163 