### PR TITLE
Remove boto3/botocore from icav2 layer installation

### DIFF
--- a/packages/lambda/index.ts
+++ b/packages/lambda/index.ts
@@ -321,6 +321,10 @@ export class PythonUvFunction extends PythonFunction {
                                 `find ${outputDir} -type d -name '__pycache__' -exec rm -rf {}/* \\;`,
                                 // Delete the __pycache__ directories themselves
                                 `find ${outputDir} -type d -name '__pycache__' -delete`,
+                                // Uninstall boto3 & botocore to avoid bloating the image
+                                // pip is aliased to 'uv pip' so no need to include --yes parameter
+                                `pip uninstall boto3 botocore`,
+                                `rm -rf ${outputDir}/boto3 ${outputDir}/botocore`,
                             ];
                         },
                     },


### PR DESCRIPTION
Remove the boto3 installation from the icav2 tools layer kit.

Already provided in the lambda image.

This layer can get close to 170 MB so we want to remove any bloating where we can