### PR TITLE
feat: split out install commands

### DIFF
--- a/packages/deployment-stack-pipeline/pipeline.ts
+++ b/packages/deployment-stack-pipeline/pipeline.ts
@@ -110,6 +110,10 @@ export interface CodeBuildStepProps {
    * Partial buildspec for this CodeBuildStep
    */
   readonly partialBuildSpec?: Record<string, any>;
+  /**
+   * The install commands to run before the main command.
+   */
+  readonly installCommands?: string[];
 }
 
 export interface DeploymentStackPipelineProps {
@@ -341,10 +345,12 @@ export class DeploymentStackPipeline extends Construct {
 
     // Add unit test for IaC at the root of the
     const {
-      command: unitIacTestCommand = [
+      installCommands: unitIacTestInstall = [
         "npm install --global corepack@latest",
         "corepack enable",
         "pnpm install --frozen-lockfile --ignore-scripts",
+      ],
+      command: unitIacTestCommand = [
         "pnpm test",
       ],
       partialBuildSpec: unitIacPartialBuildSpec = {
@@ -359,6 +365,7 @@ export class DeploymentStackPipeline extends Construct {
       },
     } = props.unitIacTestConfig || {};
     const unitIacTest = new CodeBuildStep("UnitIacTest", {
+      installCommands: unitIacTestInstall,
       commands: unitIacTestCommand,
       input: sourceFile,
       buildEnvironment: {
@@ -380,10 +387,12 @@ export class DeploymentStackPipeline extends Construct {
     // Adding unit test for the main app
     const {
       command: unitAppTestCommand,
+      installCommands: unitAppTestInstall = undefined,
       partialBuildSpec: unitAppPartialBuildSpec = undefined,
     } = props.unitAppTestConfig;
     const unitAppTest = new CodeBuildStep("UnitAppTest", {
       commands: unitAppTestCommand,
+      installCommands: unitAppTestInstall,
       input: sourceFile,
       buildEnvironment: {
         privileged: true,

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/classes/DeploymentStackPipeline.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/classes/DeploymentStackPipeline.md
@@ -6,7 +6,7 @@
 
 # Class: DeploymentStackPipeline
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:260](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L260)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:264](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L264)
 
 A CDK construct that creates a deployment pipeline across environments for the OrcaBus project.
 
@@ -23,7 +23,7 @@ before using this construct.
 
 > **new DeploymentStackPipeline**(`scope`, `id`, `props`): `DeploymentStackPipeline`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:266](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L266)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:270](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L270)
 
 #### Parameters
 
@@ -67,7 +67,7 @@ The tree node.
 
 > `readonly` **pipeline**: `Pipeline`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:264](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L264)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:268](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L268)
 
 The code pipeline construct that is created.
 

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CacheOptions.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CacheOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: CacheOptions
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:246](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L246)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:250](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L250)
 
 Options for creating an S3 cache to use across build steps. If specified, the bucket under
 `CODEBUILD_CACHE_BUCKET` will be used for caching. This bucket is managed by the shared-resources
@@ -24,7 +24,7 @@ https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build
 
 > `readonly` **namespace**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:251](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L251)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:255](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L255)
 
 Specify the namespace for the cache. This option is required because the cache bucket is shared across
 all projects so a namespace is required to uniquely identify the cache. Use the project name, e.g. `filemanager`.

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CodeBuildStepProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CodeBuildStepProps.md
@@ -20,6 +20,16 @@ the main command for the build step to run
 
 ***
 
+### installCommands?
+
+> `readonly` `optional` **installCommands**: `string`[]
+
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:116](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L116)
+
+The install commands to run before the main command.
+
+***
+
 ### partialBuildSpec?
 
 > `readonly` `optional` **partialBuildSpec**: `Record`\<`string`, `any`\>

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/DeploymentStackPipelineProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/DeploymentStackPipelineProps.md
@@ -6,7 +6,7 @@
 
 # Interface: DeploymentStackPipelineProps
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:115](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L115)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:119](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L119)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [packages/deployment-stack-pipeline/pipeline.ts:115](https://github.
 
 > `readonly` `optional` **cacheOptions**: [`CacheOptions`](CacheOptions.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:235](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L235)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:239](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L239)
 
 Configure the `cache` options for each `CodeBuildStep`. This will allow CodeBuild to use
 S3 caching with the `CODEBUILD_CACHE_BUCKET` bucket.
@@ -31,7 +31,7 @@ https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build
 
 > `readonly` `optional` **cdkOut**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:167](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L167)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:171](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L171)
 
 The location where the cdk output will be stored.
 
@@ -47,7 +47,7 @@ cdk.out
 
 > `readonly` **cdkSynthCmd**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:161](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L161)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:165](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L165)
 
 The command to run to synth the cdk stack which also installing the cdk dependencies. e.g. ["pnpm install --frozen-lockfile", "pnpm cdk synth"]
 
@@ -57,7 +57,7 @@ The command to run to synth the cdk stack which also installing the cdk dependen
 
 > `readonly` `optional` **driftCheckConfig**: [`DriftCheckConfig`](DriftCheckConfig.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:227](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L227)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:231](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L231)
 
 Configuration for drift detection checks before deployment.
 If specified, the pipeline will check for CloudFormation drift and fail if detected.
@@ -68,7 +68,7 @@ If specified, the pipeline will check for CloudFormation drift and fail if detec
 
 > `readonly` `optional` **enableSlackNotification**: `boolean`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:198](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L198)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:202](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L202)
 
 Enable notification to the 'alerts-build' slack channel.
 
@@ -84,7 +84,7 @@ True
 
 > `readonly` `optional` **excludedFilePaths**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:157](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L157)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:161](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L161)
 
 The list of patterns of Git repository file paths that, when a commit is pushed, are to be EXCLUDED from starting the pipeline.
 
@@ -96,7 +96,7 @@ https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-co
 
 > `readonly` **githubBranch**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:122](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L122)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:126](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L126)
 
 The GitHub branch name the pipeline will listen to.
 Avoid using branch names that contain special characters such as parentheses.
@@ -109,7 +109,7 @@ This restriction is due to AWS resource tagging requirements.
 
 > `readonly` **githubRepo**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:126](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L126)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:130](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L130)
 
 The repository name that exist in the 'OrcaBus' github organisation. e.g. `a-micro-service-repo`
 
@@ -119,7 +119,7 @@ The repository name that exist in the 'OrcaBus' github organisation. e.g. `a-mic
 
 > `readonly` `optional` **includedFilePaths**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:150](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L150)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:154](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L154)
 
 The list of patterns of Git repository file paths that, when a commit is pushed, are to be INCLUDED as criteria that starts the pipeline.
 
@@ -131,7 +131,7 @@ https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-co
 
 > `readonly` `optional` **notificationEvents**: `PipelineNotificationEvents`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:206](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L206)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:210](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L210)
 
 The pipeline notification events that will trigger a Slack channel notification.
 Only applies if `enableSlackNotification` is set to true.
@@ -149,7 +149,7 @@ Only applies if `enableSlackNotification` is set to true.
 
 > `readonly` **pipelineName**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:143](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L143)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:147](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L147)
 
 The pipeline name in the bastion account.
 
@@ -159,7 +159,7 @@ The pipeline name in the bastion account.
 
 > `readonly` `optional` **reuseExistingArtifactBucket**: `boolean`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:214](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L214)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:218](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L218)
 
 Whether to reuse the existing artifact bucket for cross-deployment pipelines.
 If set to true, it will look up the existing artifact bucket in the TOOLCHAIN account.
@@ -176,7 +176,7 @@ True
 
 > `readonly` **stack**: `any`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:130](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L130)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:134](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L134)
 
 The stack to which the pipeline will be deploying to its respective account
 
@@ -186,7 +186,7 @@ The stack to which the pipeline will be deploying to its respective account
 
 > `readonly` **stackConfig**: [`StackConfigProps`](StackConfigProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:139](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L139)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:143](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L143)
 
 The stack configuration/constants that will be passed to the stack props.
 
@@ -196,7 +196,7 @@ The stack configuration/constants that will be passed to the stack props.
 
 > `readonly` **stackName**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:135](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L135)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:139](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L139)
 
 The stack name (in cloudformation) for the stack defined in `stack`. The stack name will prepend with the stage
 name e.g. `OrcaBusBeta-<stackName>`, `OrcaBusGamma-<stackName>`, `OrcaBusProd-<stackName>`
@@ -207,7 +207,7 @@ name e.g. `OrcaBusBeta-<stackName>`, `OrcaBusGamma-<stackName>`, `OrcaBusProd-<s
 
 > `readonly` `optional` **stageEnv**: [`StageEnvProps`](StageEnvProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:193](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L193)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:197](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L197)
 
 The stage environment for the deployment stack
 
@@ -217,7 +217,7 @@ The stage environment for the deployment stack
 
 > `readonly` `optional` **stripAssemblyAssets**: `boolean`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:222](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L222)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:226](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L226)
 
 Remove assets from the CDK assembly pre-deployment to prevent hitting CodePipeline's 256 MB artifact size limit.
 Useful when CDK assets (Lambda code, Docker images, etc.) are large.
@@ -232,7 +232,7 @@ https://github.com/aws/aws-cdk/issues/9917
 
 > `readonly` `optional` **synthBuildSpec**: `Record`\<`string`, `any`\>
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:173](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L173)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:177](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L177)
 
 Additional configuration for the CodeBuild step during the CDK synth phase. It will passed as the `partialBuildSpec` to the `CodeBuildStep`.
 
@@ -248,7 +248,7 @@ DEFAULT_SYNTH_STEP_PARTIAL_BUILD_SPEC
 
 > `readonly` **unitAppTestConfig**: [`CodeBuildStepProps`](CodeBuildStepProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:181](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L181)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:185](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L185)
 
 Configuration for the CodeBuild step that runs unit tests for the main application code.
 This step will execute in parallel with [unitIacTestConfig](#unitiactestconfig) as part of the synth stage dependencies.
@@ -262,7 +262,7 @@ ensure your command includes 'cd' to the main app directory, as the build contex
 
 > `readonly` `optional` **unitIacTestConfig**: [`CodeBuildStepProps`](CodeBuildStepProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:189](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L189)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:193](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L193)
 
 Configuration for the CodeBuild step that runs unit tests for Infrastructure-as-Code (IaC) at the repository root.
 This step will execute in parallel with [unitAppTestConfig](#unitapptestconfig) as part of the synth stage dependencies.

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/FailOnDriftBuildStepProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/FailOnDriftBuildStepProps.md
@@ -6,7 +6,7 @@
 
 # Interface: FailOnDriftBuildStepProps
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:680](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L680)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:689](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L689)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [packages/deployment-stack-pipeline/pipeline.ts:680](https://github.
 
 > `readonly` **accountEnv**: `Environment`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:685](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L685)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:694](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L694)
 
 AWS account and region where the drift check runs.
 Used to assume the CDK lookup role and set AWS_DEFAULT_REGION.
@@ -25,7 +25,7 @@ Used to assume the CDK lookup role and set AWS_DEFAULT_REGION.
 
 > `readonly` **cdkCommand**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:699](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L699)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:708](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L708)
 
 CDK CLI entrypoint used to run the drift command.
 Examples: "pnpm cdk", "pnpm cdk-stateful", "pnpm cdk-stateless".
@@ -37,7 +37,7 @@ Must support: "drift <stackId>".
 
 > `readonly` `optional` **installCommand**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:707](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L707)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:716](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L716)
 
 Command to install dependencies before running CDK.
 If your app is in a subdirectory, prefix with "cd <dir> &&".
@@ -51,7 +51,7 @@ Default: "pnpm install --frozen-lockfile --ignore-scripts"
 
 > `readonly` **stackId**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:693](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L693)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:702](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L702)
 
 Fully qualified CDK stack ID to check for drift.
 


### PR DESCRIPTION
I think the install commands for test CodeBuild steps should be separated so that they don't have to be repeated when a service wants to customize the test command. This shouldn't change the default behaviour as it currently is.

### Changes
* Move install commands inside `DeploymentStackPipeline` to separate option for test steps.