### PR TITLE
feat: update build image and allow setting it

### DIFF
--- a/packages/deployment-stack-pipeline/pipeline.ts
+++ b/packages/deployment-stack-pipeline/pipeline.ts
@@ -5,6 +5,7 @@ import {
   BuildSpec,
   Cache,
   ComputeType,
+  IBuildImage,
   LinuxArmBuildImage,
 } from "aws-cdk-lib/aws-codebuild";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
@@ -204,6 +205,12 @@ export interface DeploymentStackPipelineProps {
    */
   readonly synthInstallCommands?: string[];
   /**
+   * The CodeBuild image to use for the build steps.
+   *
+   * @default LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0
+   */
+  readonly buildImage?: IBuildImage;
+  /**
    * Configuration for the CodeBuild step that runs unit tests for the main application code.
    * This step will execute in parallel with {@link unitIacTestConfig} as part of the synth stage dependencies.
    * Both must succeed before the synth step runs.
@@ -400,6 +407,8 @@ export class DeploymentStackPipeline extends Construct {
     } = props.unitIacTestConfig || {};
     setCachePaths(unitIacPartialBuildSpec);
 
+    const buildImage =
+      props.buildImage ?? LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0;
     const unitIacTest = new CodeBuildStep("UnitIacTest", {
       installCommands: unitIacTestInstall,
       commands: unitIacTestCommand,
@@ -407,7 +416,7 @@ export class DeploymentStackPipeline extends Construct {
       buildEnvironment: {
         privileged: true,
         computeType: ComputeType.LARGE,
-        buildImage: LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
+        buildImage,
         environmentVariables: {
           NODE_OPTIONS: {
             value: "--max-old-space-size=8192",
@@ -439,7 +448,7 @@ export class DeploymentStackPipeline extends Construct {
       buildEnvironment: {
         privileged: true,
         computeType: ComputeType.LARGE,
-        buildImage: LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
+        buildImage,
         environmentVariables: {
           NODE_OPTIONS: {
             value: "--max-old-space-size=8192",
@@ -479,7 +488,7 @@ export class DeploymentStackPipeline extends Construct {
       codeBuildDefaults: {
         buildEnvironment: {
           computeType: ComputeType.LARGE,
-          buildImage: LinuxArmBuildImage.AMAZON_LINUX_2_STANDARD_3_0,
+          buildImage,
           environmentVariables: {
             NODE_OPTIONS: {
               value: "--max-old-space-size=8192",

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/classes/DeploymentStackPipeline.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/classes/DeploymentStackPipeline.md
@@ -6,7 +6,7 @@
 
 # Class: DeploymentStackPipeline
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:301](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L301)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:308](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L308)
 
 A CDK construct that creates a deployment pipeline across environments for the OrcaBus project.
 
@@ -23,7 +23,7 @@ before using this construct.
 
 > **new DeploymentStackPipeline**(`scope`, `id`, `props`): `DeploymentStackPipeline`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:307](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L307)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:314](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L314)
 
 #### Parameters
 
@@ -67,7 +67,7 @@ The tree node.
 
 > `readonly` **pipeline**: `Pipeline`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:305](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L305)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:312](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L312)
 
 The code pipeline construct that is created.
 

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CacheOptions.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CacheOptions.md
@@ -6,7 +6,7 @@
 
 # Interface: CacheOptions
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:275](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L275)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:282](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L282)
 
 Options for creating an S3 cache to use across build steps. If specified, the bucket under
 `CODEBUILD_CACHE_BUCKET` will be used for caching. This bucket is managed by the shared-resources
@@ -18,7 +18,7 @@ service.
 
 > `readonly` **namespace**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:280](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L280)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:287](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L287)
 
 Specify the namespace for the cache. This option is required because the cache bucket is shared across
 all projects so a namespace is required to uniquely identify the cache. Use the project name, e.g. `filemanager`.
@@ -29,7 +29,7 @@ all projects so a namespace is required to uniquely identify the cache. Use the 
 
 > `readonly` `optional` **paths?**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:292](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L292)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:299](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L299)
 
 The paths to cache. This will default to the `node_modules` directory if unspecified.
 
@@ -46,6 +46,6 @@ https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build
 
 > `readonly` `optional` **prefix?**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:284](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L284)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:291](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L291)
 
 The prefix for the cache controlling the prefix on S3. If left unspecified, this will default to the namespace.

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CodeBuildStepProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/CodeBuildStepProps.md
@@ -6,7 +6,7 @@
 
 # Interface: CodeBuildStepProps
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:117](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L117)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:118](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L118)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [packages/deployment-stack-pipeline/pipeline.ts:117](https://github.
 
 > `readonly` **command**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:121](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L121)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:122](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L122)
 
 the main command for the build step to run
 
@@ -24,7 +24,7 @@ the main command for the build step to run
 
 > `readonly` `optional` **installCommands?**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:129](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L129)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:130](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L130)
 
 The install commands to run before the main command.
 
@@ -34,7 +34,7 @@ The install commands to run before the main command.
 
 > `readonly` `optional` **partialBuildSpec?**: `Record`\<`string`, `any`\>
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:125](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L125)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:126](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L126)
 
 Partial buildspec for this CodeBuildStep
 
@@ -44,6 +44,6 @@ Partial buildspec for this CodeBuildStep
 
 > `readonly` `optional` **rolePolicyStatements?**: `PolicyStatement`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:133](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L133)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:134](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L134)
 
 The additional policy statements to add to the CodeBuildStep role.

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/DeploymentStackPipelineProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/DeploymentStackPipelineProps.md
@@ -6,15 +6,31 @@
 
 # Interface: DeploymentStackPipelineProps
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:136](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L136)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:137](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L137)
 
 ## Properties
+
+### buildImage?
+
+> `readonly` `optional` **buildImage?**: `IBuildImage`
+
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:212](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L212)
+
+The CodeBuild image to use for the build steps.
+
+#### Default
+
+```ts
+LinuxArmBuildImage.AMAZON_LINUX_2023_STANDARD_3_0
+```
+
+***
 
 ### cacheOptions?
 
 > `readonly` `optional` **cacheOptions?**: [`CacheOptions`](CacheOptions.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:267](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L267)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:274](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L274)
 
 Configure the `cache` options for each `CodeBuildStep`. This will allow CodeBuild to use
 S3 caching with the `CODEBUILD_CACHE_BUCKET` bucket.
@@ -31,7 +47,7 @@ https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html#build
 
 > `readonly` `optional` **cdkOut?**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:192](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L192)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:193](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L193)
 
 The location where the cdk output will be stored.
 
@@ -47,7 +63,7 @@ cdk.out
 
 > `readonly` **cdkSynthCmd**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:182](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L182)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:183](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L183)
 
 The command to run to synth the cdk stack which also installing the cdk dependencies. e.g. ["pnpm install --frozen-lockfile", "pnpm cdk synth"]
 
@@ -57,7 +73,7 @@ The command to run to synth the cdk stack which also installing the cdk dependen
 
 > `readonly` `optional` **driftCheckConfig?**: [`DriftCheckConfig`](DriftCheckConfig.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:259](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L259)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:266](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L266)
 
 Configuration for drift detection checks before deployment.
 If specified, the pipeline will check for CloudFormation drift and fail if detected.
@@ -68,7 +84,7 @@ If specified, the pipeline will check for CloudFormation drift and fail if detec
 
 > `readonly` `optional` **enableSlackNotification?**: `boolean`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:230](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L230)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:237](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L237)
 
 Enable notification to the 'alerts-build' slack channel.
 
@@ -84,7 +100,7 @@ True
 
 > `readonly` `optional` **excludedFilePaths?**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:178](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L178)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:179](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L179)
 
 The list of patterns of Git repository file paths that, when a commit is pushed, are to be EXCLUDED from starting the pipeline.
 
@@ -96,7 +112,7 @@ https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-co
 
 > `readonly` **githubBranch**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:143](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L143)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:144](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L144)
 
 The GitHub branch name the pipeline will listen to.
 Avoid using branch names that contain special characters such as parentheses.
@@ -109,7 +125,7 @@ This restriction is due to AWS resource tagging requirements.
 
 > `readonly` **githubRepo**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:147](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L147)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:148](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L148)
 
 The repository name that exist in the 'OrcaBus' github organisation. e.g. `a-micro-service-repo`
 
@@ -119,7 +135,7 @@ The repository name that exist in the 'OrcaBus' github organisation. e.g. `a-mic
 
 > `readonly` `optional` **includedFilePaths?**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:171](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L171)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:172](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L172)
 
 The list of patterns of Git repository file paths that, when a commit is pushed, are to be INCLUDED as criteria that starts the pipeline.
 
@@ -131,7 +147,7 @@ https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-co
 
 > `readonly` `optional` **notificationEvents?**: `PipelineNotificationEvents`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:238](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L238)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:245](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L245)
 
 The pipeline notification events that will trigger a Slack channel notification.
 Only applies if `enableSlackNotification` is set to true.
@@ -149,7 +165,7 @@ Only applies if `enableSlackNotification` is set to true.
 
 > `readonly` **pipelineName**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:164](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L164)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:165](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L165)
 
 The pipeline name in the bastion account.
 
@@ -159,7 +175,7 @@ The pipeline name in the bastion account.
 
 > `readonly` `optional` **reuseExistingArtifactBucket?**: `boolean`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:246](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L246)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:253](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L253)
 
 Whether to reuse the existing artifact bucket for cross-deployment pipelines.
 If set to true, it will look up the existing artifact bucket in the TOOLCHAIN account.
@@ -176,7 +192,7 @@ True
 
 > `readonly` **stack**: `any`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:151](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L151)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:152](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L152)
 
 The stack to which the pipeline will be deploying to its respective account
 
@@ -186,7 +202,7 @@ The stack to which the pipeline will be deploying to its respective account
 
 > `readonly` **stackConfig**: [`StackConfigProps`](StackConfigProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:160](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L160)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:161](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L161)
 
 The stack configuration/constants that will be passed to the stack props.
 
@@ -196,7 +212,7 @@ The stack configuration/constants that will be passed to the stack props.
 
 > `readonly` **stackName**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:156](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L156)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:157](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L157)
 
 The stack name (in cloudformation) for the stack defined in `stack`. The stack name will prepend with the stage
 name e.g. `OrcaBusBeta-<stackName>`, `OrcaBusGamma-<stackName>`, `OrcaBusProd-<stackName>`
@@ -207,7 +223,7 @@ name e.g. `OrcaBusBeta-<stackName>`, `OrcaBusGamma-<stackName>`, `OrcaBusProd-<s
 
 > `readonly` `optional` **stageEnv?**: [`StageEnvProps`](StageEnvProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:225](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L225)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:232](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L232)
 
 The stage environment for the deployment stack
 
@@ -217,7 +233,7 @@ The stage environment for the deployment stack
 
 > `readonly` `optional` **stripAssemblyAssets?**: `boolean`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:254](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L254)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:261](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L261)
 
 Remove assets from the CDK assembly pre-deployment to prevent hitting CodePipeline's 256 MB artifact size limit.
 Useful when CDK assets (Lambda code, Docker images, etc.) are large.
@@ -232,7 +248,7 @@ https://github.com/aws/aws-cdk/issues/9917
 
 > `readonly` `optional` **synthBuildSpec?**: `Record`\<`string`, `any`\>
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:199](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L199)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:200](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L200)
 
 Additional configuration for the CodeBuild step during the CDK synth phase. It will be passed as the
 `partialBuildSpec` to the `CodeBuildStep`.
@@ -249,7 +265,7 @@ DEFAULT_PARTIAL_BUILD_SPEC
 
 > `readonly` `optional` **synthInstallCommands?**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:205](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L205)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:206](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L206)
 
 The install commands for the synth step.
 
@@ -265,7 +281,7 @@ DEFAULT_INSTALL_COMMANDS
 
 > `readonly` `optional` **synthRolePolicyStatements?**: `PolicyStatement`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:186](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L186)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:187](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L187)
 
 The additional policy statements to add to the CodeBuildStep role during the synth step.
 
@@ -275,7 +291,7 @@ The additional policy statements to add to the CodeBuildStep role during the syn
 
 > `readonly` **unitAppTestConfig**: [`CodeBuildStepProps`](CodeBuildStepProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:213](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L213)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:220](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L220)
 
 Configuration for the CodeBuild step that runs unit tests for the main application code.
 This step will execute in parallel with [unitIacTestConfig](#unitiactestconfig) as part of the synth stage dependencies.
@@ -289,7 +305,7 @@ ensure your command includes 'cd' to the main app directory, as the build contex
 
 > `readonly` `optional` **unitIacTestConfig?**: [`CodeBuildStepProps`](CodeBuildStepProps.md)
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:221](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L221)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:228](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L228)
 
 Configuration for the CodeBuild step that runs unit tests for Infrastructure-as-Code (IaC) at the repository root.
 This step will execute in parallel with [unitAppTestConfig](#unitapptestconfig) as part of the synth stage dependencies.

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/DriftCheckConfig.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/DriftCheckConfig.md
@@ -6,7 +6,7 @@
 
 # Interface: DriftCheckConfig
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:100](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L100)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:101](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L101)
 
 Configuration for pre-deployment drift detection checks.
 
@@ -16,7 +16,7 @@ Configuration for pre-deployment drift detection checks.
 
 > `readonly` **cdkCommand**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:106](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L106)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:107](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L107)
 
 CDK CLI entrypoint used to run the drift command.
 Examples: "pnpm cdk", "pnpm cdk-stateful", "pnpm cdk-stateless".
@@ -28,7 +28,7 @@ Must support: "drift <stackId>".
 
 > `readonly` `optional` **installCommand?**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:114](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L114)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:115](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L115)
 
 Command to install dependencies before running CDK.
 If your app is in a subdirectory, prefix with "cd <dir> &&".

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/FailOnDriftBuildStepProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/FailOnDriftBuildStepProps.md
@@ -6,7 +6,7 @@
 
 # Interface: FailOnDriftBuildStepProps
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:732](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L732)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:741](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L741)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [packages/deployment-stack-pipeline/pipeline.ts:732](https://github.
 
 > `readonly` **accountEnv**: `Environment`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:737](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L737)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:746](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L746)
 
 AWS account and region where the drift check runs.
 Used to assume the CDK lookup role and set AWS_DEFAULT_REGION.
@@ -25,7 +25,7 @@ Used to assume the CDK lookup role and set AWS_DEFAULT_REGION.
 
 > `readonly` **cdkCommand**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:751](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L751)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:760](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L760)
 
 CDK CLI entrypoint used to run the drift command.
 Examples: "pnpm cdk", "pnpm cdk-stateful", "pnpm cdk-stateless".
@@ -37,7 +37,7 @@ Must support: "drift <stackId>".
 
 > `readonly` `optional` **installCommand?**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:759](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L759)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:768](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L768)
 
 Command to install dependencies before running CDK.
 If your app is in a subdirectory, prefix with "cd <dir> &&".
@@ -55,7 +55,7 @@ DEFAULT_INSTALL_COMMANDS merged with &&.
 
 > `readonly` **stackId**: `string`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:745](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L745)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:754](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L754)
 
 Fully qualified CDK stack ID to check for drift.
 

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/StackConfigProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/StackConfigProps.md
@@ -6,7 +6,7 @@
 
 # Interface: StackConfigProps
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:82](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L82)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:83](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L83)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [packages/deployment-stack-pipeline/pipeline.ts:82](https://github.c
 
 > `readonly` **beta**: `Record`\<`string`, `any`\>
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:86](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L86)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:87](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L87)
 
 The configuration for the beta (dev) stage
 
@@ -24,7 +24,7 @@ The configuration for the beta (dev) stage
 
 > `readonly` **gamma**: `Record`\<`string`, `any`\>
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:90](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L90)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:91](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L91)
 
 The configuration for the gamma (stg) stage
 
@@ -34,6 +34,6 @@ The configuration for the gamma (stg) stage
 
 > `readonly` **prod**: `Record`\<`string`, `any`\>
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:94](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L94)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:95](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L95)
 
 The configuration for the prod stage

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/StageEnvProps.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/interfaces/StageEnvProps.md
@@ -6,7 +6,7 @@
 
 # Interface: StageEnvProps
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:67](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L67)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:68](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L68)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [packages/deployment-stack-pipeline/pipeline.ts:67](https://github.c
 
 > `readonly` **beta**: `Environment`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:71](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L71)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:72](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L72)
 
 The environment for the beta stage
 
@@ -24,7 +24,7 @@ The environment for the beta stage
 
 > `readonly` **gamma**: `Environment`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:75](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L75)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:76](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L76)
 
 The environment for the gamma stage
 
@@ -34,6 +34,6 @@ The environment for the gamma stage
 
 > `readonly` **prod**: `Environment`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:79](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L79)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:80](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L80)
 
 The environment for the prod stage

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/variables/DEFAULT_INSTALL_COMMANDS.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/variables/DEFAULT_INSTALL_COMMANDS.md
@@ -8,6 +8,6 @@
 
 > `const` **DEFAULT\_INSTALL\_COMMANDS**: `string`[]
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:59](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L59)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:60](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L60)
 
 The default install commands for CodeBuild steps.

--- a/packages/docs/@orcabus/namespaces/deploymentPipeline/variables/DEFAULT_PARTIAL_BUILD_SPEC.md
+++ b/packages/docs/@orcabus/namespaces/deploymentPipeline/variables/DEFAULT_PARTIAL_BUILD_SPEC.md
@@ -8,7 +8,7 @@
 
 > `const` **DEFAULT\_PARTIAL\_BUILD\_SPEC**: `object`
 
-Defined in: [packages/deployment-stack-pipeline/pipeline.ts:45](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L45)
+Defined in: [packages/deployment-stack-pipeline/pipeline.ts:46](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/deployment-stack-pipeline/pipeline.ts#L46)
 
 The default partial build spec for code build steps in the pipeline.
 


### PR DESCRIPTION
### Changes
* Allows setting the build image, and also updates to AL2023 as the default.

This allows users to set node 24. I think the upgrade to AL2023 shouldn't be an issue (I'm not sure if it was Amazon Linux 2 for a specific reason, or maybe it just hasn't been updated in a while?)