### PR TITLE
Upgrades FastAPI Toolkit for Mangum

### DIFF
--- a/packages/lambda/layers/fastapi_tools/poetry.lock
+++ b/packages/lambda/layers/fastapi_tools/poetry.lock
@@ -284,14 +284,14 @@ wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
 
 [[package]]
 name = "dyntastic"
-version = "0.16.0"
+version = "0.18.0"
 description = "A DynamoDB library on top of Pydantic and boto3."
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "dyntastic-0.16.0-py3-none-any.whl", hash = "sha256:24508d58a0e98c65900e4c09477ba7f1728e92f605a11fbe83bb4e44dd189e44"},
-    {file = "dyntastic-0.16.0.tar.gz", hash = "sha256:56820083b657384f2956d0f65d48c3171a10d135f57ce7b40e0030a1c1be0cf7"},
+    {file = "dyntastic-0.18.0-py3-none-any.whl", hash = "sha256:6b813105cf9526e27e4a1df0e5b79aef7aee994ee8cd1f5382cc37526c113034"},
+    {file = "dyntastic-0.18.0.tar.gz", hash = "sha256:dbf3ab1b9cfb87d36101ae54d0d206d9d7f23c5700940011066c81d3b8f91a1c"},
 ]
 
 [package.dependencies]
@@ -719,14 +719,14 @@ files = [
 
 [[package]]
 name = "mangum"
-version = "0.19.0"
+version = "0.21.0"
 description = "AWS Lambda support for ASGI applications"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "mangum-0.19.0-py3-none-any.whl", hash = "sha256:e500b35f495d5e68ac98bc97334896d6101523f2ee2c57ba6a61893b65266e59"},
-    {file = "mangum-0.19.0.tar.gz", hash = "sha256:e388e7c491b7b67970f8234e46fd4a7b21ff87785848f418de08148f71cf0bd6"},
+    {file = "mangum-0.21.0-py3-none-any.whl", hash = "sha256:309e48f5c629542516c5106ecf079f4ec08809ed50df882238d98fe1392820c7"},
+    {file = "mangum-0.21.0.tar.gz", hash = "sha256:e31ed72d67f9958fa4379f65df77729906dec6dfa00afa6ed4e06c77833000de"},
 ]
 
 [package.dependencies]
@@ -1994,4 +1994,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.14, <3.15"
-content-hash = "426c38d55ce1eba9b607f234fc2b5f1e2ee9870afcc8ce5ae12ea4ad49fbb8e6"
+content-hash = "3504db3db70645197b2b25fbe4501d4e85b2e79b8136484c5d2dc0524f7e2e55"

--- a/packages/lambda/layers/fastapi_tools/pyproject.toml
+++ b/packages/lambda/layers/fastapi_tools/pyproject.toml
@@ -15,12 +15,12 @@ repository = "https://github.com/orcabus/platform-cdk-constructs"
 
 [tool.poetry.dependencies]
 python = "^3.14, <3.15"
-fastapi = {extras = ["standard"], version = ">=0.115.6"}
-pydantic = "^2.10.5"
-mangum = "^0.19.0"
-dyntastic = "^0.16.0"
+fastapi = {extras = ["standard"], version = ">=0.136.1"}
+pydantic = "^2.13.4"
+mangum = "^0.21.0"
+dyntastic = "^0.18.0"
 ulid-py = "^1.1.0"
-requests = "^2.32.3"
+requests = "^2.34.2"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
Upgrades the `mangum` package within the FastAPI tools layer. This update enhances compatibility and leverages improvements for Lambda API interfaces.

Consequently, this also updates other core dependencies such as `fastapi`, `pydantic`, `dyntastic`, and `requests` to their latest compatible versions. This aligns `mangum`'s minimum Python version requirement with newer standards, ensuring optimal performance and stability.