### PR TITLE
Make Bam URI Optional

### DIFF
--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/job_helpers.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/job_helpers.py
@@ -7,7 +7,7 @@ Update helpers for the update script.
 - run_ntsm
 - run_file_compression_information
 """
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 # Standard imports
 
@@ -69,7 +69,7 @@ def run_read_count_stats(fastq_id: str) -> Job:
 def run_extract_fingerprint(
         fastq_set_id: str,
         reference_name: str,
-        bam_uri: str
+        bam_uri: Optional[str]
 ) -> Dict[str, Any]:
     """
     Run extract fingerprint for a fastq_set_id.
@@ -83,7 +83,11 @@ def run_extract_fingerprint(
         params={
             "referenceName": reference_name
         },
-        json_data={
-            "s3Uri": bam_uri
-        }
+        json_data=(
+            {
+                "s3Uri": bam_uri
+            }
+            if bam_uri is not None
+            else None
+        )
     )

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/models.py
@@ -39,7 +39,9 @@ from typing import (
     TypedDict,
     Optional,
     Dict,
-    List, NotRequired, Union,
+    List,
+    NotRequired,
+    Union,
     Literal
 )
 from datetime import datetime

--- a/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/models.py
+++ b/packages/lambda/layers/orcabus_api_tools/src/orcabus_api_tools/fastq/models.py
@@ -188,7 +188,7 @@ class FastqSet(TypedDict):
     fastqSet: List[Fastq]
     allowAdditionalFastq: bool
     isCurrentFastqSet: bool
-
+    somalier: Optional[FileStorageObject]
 
 class ReadCount(TypedDict):
     readCount: int


### PR DESCRIPTION
*   Allows the `extract fingerprint` workflow to be initiated with an optional BAM URI, providing greater flexibility.
*   Adds an optional `somalier` field to the `FastqSet` model, enabling richer data representation for FastQ sets.
*   Updates Python typing imports in the FastQ models for clarity and consistency.