### PR TITLE
improve api gateway cors

### DIFF
--- a/packages/api-gateway/api-gateway.ts
+++ b/packages/api-gateway/api-gateway.ts
@@ -67,6 +67,14 @@ export interface OrcaBusApiGatewayProps {
    * Allowed CORS origins.
    */
   readonly corsAllowOrigins: string[];
+  /**
+   * Allowed CORS headers.
+   */
+  readonly corsAllowHeaders?: string[];
+  /**
+   * The headers that are exposed to the client.
+   */
+  readonly corsExposeHeaders?: string[];
 }
 
 export class OrcaBusApiGateway extends Construct {
@@ -127,6 +135,7 @@ export class OrcaBusApiGateway extends Construct {
           "x-api-key",
           "x-amz-security-token",
           "x-amz-user-agent",
+          ...(props.corsAllowHeaders ?? []),
         ],
         allowMethods: [
           CorsHttpMethod.GET,
@@ -135,7 +144,9 @@ export class OrcaBusApiGateway extends Construct {
           CorsHttpMethod.POST,
           CorsHttpMethod.PATCH,
           CorsHttpMethod.DELETE,
+          CorsHttpMethod.PUT,
         ],
+        exposeHeaders: props.corsExposeHeaders,
         allowOrigins: props.corsAllowOrigins,
         maxAge: Duration.days(10),
       },

--- a/packages/docs/@orcabus/namespaces/apigateway/classes/OrcaBusApiGateway.md
+++ b/packages/docs/@orcabus/namespaces/apigateway/classes/OrcaBusApiGateway.md
@@ -6,7 +6,7 @@
 
 # Class: OrcaBusApiGateway
 
-Defined in: [packages/api-gateway/api-gateway.ts:72](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L72)
+Defined in: [packages/api-gateway/api-gateway.ts:80](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L80)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [packages/api-gateway/api-gateway.ts:72](https://github.com/OrcaBus/
 
 > **new OrcaBusApiGateway**(`scope`, `id`, `props`): `OrcaBusApiGateway`
 
-Defined in: [packages/api-gateway/api-gateway.ts:94](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L94)
+Defined in: [packages/api-gateway/api-gateway.ts:102](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L102)
 
 #### Parameters
 
@@ -48,7 +48,7 @@ Defined in: [packages/api-gateway/api-gateway.ts:94](https://github.com/OrcaBus/
 
 > `readonly` **authStackHttpLambdaAuthorizer**: `HttpLambdaAuthorizer`
 
-Defined in: [packages/api-gateway/api-gateway.ts:92](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L92)
+Defined in: [packages/api-gateway/api-gateway.ts:100](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L100)
 
 The Lambda HTTP Authorizer used to enforce authorization policies
 defined in the authorization stack.
@@ -62,7 +62,7 @@ Example: `authorizer: apiGateway.authStackHttpLambdaAuthorizer`
 
 > `readonly` **domainName**: `string`
 
-Defined in: [packages/api-gateway/api-gateway.ts:84](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L84)
+Defined in: [packages/api-gateway/api-gateway.ts:92](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L92)
 
 Domain name defined in this gateway
 
@@ -72,7 +72,7 @@ Domain name defined in this gateway
 
 > `readonly` **httpApi**: `HttpApi`
 
-Defined in: [packages/api-gateway/api-gateway.ts:80](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L80)
+Defined in: [packages/api-gateway/api-gateway.ts:88](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L88)
 
 The HTTP API
 
@@ -96,7 +96,7 @@ The tree node.
 
 > `readonly` **region**: `string`
 
-Defined in: [packages/api-gateway/api-gateway.ts:76](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L76)
+Defined in: [packages/api-gateway/api-gateway.ts:84](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L84)
 
 The AWS region where the API Gateway is deployed.
 

--- a/packages/docs/@orcabus/namespaces/apigateway/interfaces/OrcaBusApiGatewayProps.md
+++ b/packages/docs/@orcabus/namespaces/apigateway/interfaces/OrcaBusApiGatewayProps.md
@@ -60,6 +60,16 @@ DEFAULT_COGNITO_USER_POOL_ID_PARAMETER_NAME
 
 ***
 
+### corsAllowHeaders?
+
+> `readonly` `optional` **corsAllowHeaders?**: `string`[]
+
+Defined in: [packages/api-gateway/api-gateway.ts:73](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L73)
+
+Allowed CORS headers.
+
+***
+
 ### corsAllowOrigins
 
 > `readonly` **corsAllowOrigins**: `string`[]
@@ -67,6 +77,16 @@ DEFAULT_COGNITO_USER_POOL_ID_PARAMETER_NAME
 Defined in: [packages/api-gateway/api-gateway.ts:69](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L69)
 
 Allowed CORS origins.
+
+***
+
+### corsExposeHeaders?
+
+> `readonly` `optional` **corsExposeHeaders?**: `string`[]
+
+Defined in: [packages/api-gateway/api-gateway.ts:77](https://github.com/OrcaBus/platform-cdk-constructs/blob/main/packages/api-gateway/api-gateway.ts#L77)
+
+The headers that are exposed to the client.
 
 ***
 


### PR DESCRIPTION
## Summary

Resolve issue https://github.com/OrcaBus/platform-cdk-constructs/issues/246

Make `OrcaBusApiGateway` CORS configuration more extensible for service-specific API requirements.

This PR adds:

- optional `corsAllowHeaders`
- optional `corsExposeHeaders`
- `PUT` to the default CORS allowed methods

## Changes

- Added `corsAllowHeaders?: string[]` to `OrcaBusApiGatewayProps`
- Added `corsExposeHeaders?: string[]` to `OrcaBusApiGatewayProps`
- Appended `props.corsAllowHeaders` to the default CORS `allowHeaders`
- Added `CorsHttpMethod.PUT` to default CORS `allowMethods`
- Passed `props.corsExposeHeaders` to `corsPreflight.exposeHeaders`

## Compatibility

Existing services keep the same default CORS behavior unless they opt in to the new props.

`corsAllowOrigins` behavior is unchanged.